### PR TITLE
Corrected typos, added a section on value cursors and OUT. (#71)

### DIFF
--- a/CQL_Guide/generated/internal.html
+++ b/CQL_Guide/generated/internal.html
@@ -267,6 +267,16 @@
 <li><a href="#expressions">Expressions</a></li>
 <li><a href="#basic-control-flow-patterns">Basic Control Flow Patterns</a></li>
 <li><a href="#cleanup-and-errors">Cleanup and Errors</a></li>
+<li><a href="#string-literals">String Literals</a></li>
+<li><a href="#executing-sqlite-statements">Executing SQLite Statements</a></li>
+<li><a href="#reading-single-values">Reading Single Values</a></li>
+<li><a href="#reading-rows-with-cursors">Reading Rows With Cursors</a></li>
+<li><a href="#fetching-data-from-cursors">Fetching Data From Cursors</a></li>
+<li><a href="#cursors-with-storage">Cursors With Storage</a></li>
+<li><a href="#flowing-sqlite-statements-between-procedures">Flowing SQLite Statements Between Procedures</a></li>
+<li><a href="#value-cursors">Value Cursors</a></li>
+<li><a href="#returning-value-cursors">Returning Value Cursors</a></li>
+<li><a href="#next-result-sets-and-out-union">Next: Result Sets and OUT UNION</a></li>
 </ul></li>
 </ul>
 </nav>
@@ -787,24 +797,25 @@ AST(or)</code></pre>
 -- LICENSE file in the root directory of this source tree.
 -->
 <h3 id="preface-1">Preface</h3>
-<p>Part 2 continues with a discussion of the essentials of the semantic analysis pass of the CQL compiler. As in the previous sections, the goal here is not to go over every single rule but rather to give a sense of how semantic analysis happens in general – the core strategies and implementation choices – so that when reading the code you have an idea how smaller pieces fit into the whole. To accomplish this, various key data structures will be explained in detail as well as selected examples of their use.</p>
+<p>Part 2 continues with a discussion of the essentials of the semantic analysis pass of the CQL compiler. As in the previous sections, the goal here is not to go over every single rule but rather to give a sense of how semantic analysis happens in general – the core strategies and implementation choices – so that when reading the code you will have an idea how smaller pieces fit into the whole. To accomplish this, various key data structures will be explained in detail as well as selected examples of their use.</p>
 <h2 id="semantic-analysis">Semantic Analysis</h2>
-<p>The overall goal of the semantic analysis pass is to verify that a correct program has been submitted to the compiler. The compiler does this by “decorating” the AST with semantic information. This information is mainly concerned about the “types” of the various things in the program. A key function of the semantic analyzer, the primary “weapon” in computing these types if you will, is name resolution. The semantic analyzer decides what any given name means in any context and then uses that meaning, which is itself based on the AST constructs that came before, to compute types and then check those types for errors.</p>
+<p>The overall goal of the semantic analysis pass is to verify that a correct program has been submitted to the compiler. The compiler does this by “decorating” the AST with semantic information. This information is mainly concerned with the “types” of the various things in the program. A key function of the semantic analyzer, the primary “weapon” in computing these types if you will, is name resolution. The semantic analyzer decides what any given name means in any context and then uses that meaning, which is itself based on the AST constructs that came before, to compute types and then check those types for errors.</p>
 <p>Broadly speaking the errors that can be discovered are of these forms:</p>
 <ul>
 <li>mentioned names do not exist
 <ul>
 <li>e.g. using a variable or table or column without declaring it</li>
 </ul></li>
-<li>mentioned names are not unique or are ambiguous
+<li>mentioned names are not unique, or are ambiguous
 <ul>
-<li>e.g. table names need to be unique or aliased when joining tables</li>
+<li>e.g. every view must have a unique name</li>
+<li>e.g. table names need to be unique, or aliased when joining tables</li>
 </ul></li>
-<li>operands are not compatible with each other or with the operation
+<li>operands are not compatible with each other or with the intended operation
 <ul>
 <li>e.g. you can’t add a string to a real</li>
-<li>e.g. you can’t do the ‘%’ operation on a real</li>
-<li>e.g. the expression in a <code>WHERE</code> clause must be numeric</li>
+<li>e.g. you can’t do the <code>%</code> operation on a real</li>
+<li>e.g. the expression in a <code>WHERE</code> clause must result in a numeric</li>
 <li>e.g. the first argument to <code>printf</code> must be a string literal.</li>
 <li>e.g. you can’t assign a long value to an integer variable</li>
 <li>e.g. you can’t assign a possibly null result to a not-null variable</li>
@@ -822,7 +833,7 @@ AST(or)</code></pre>
 </ul>
 <p>There are several hundred possible errors, no attempt will be made to cover them all here but we will talk about how errors are created, recorded, and reported.</p>
 <h3 id="decorated-ast-examples">Decorated AST examples</h3>
-<p>Recalling the AST output from Part 1, this is what it looks like with semantic information attached.</p>
+<p>Recalling the AST output from <a href="https://cgsql.dev/cql-guide/int01">Part 1</a>, this is what that same tree looks like with semantic information attached.</p>
 <pre><code>LET X := 1 + 3;
 
   {let_stmt}: X: integer notnull variable
@@ -859,9 +870,9 @@ AST(or)</code></pre>
 <h3 id="the-base-data-structures">The Base Data Structures</h3>
 <p>First recall that every AST node has this field in it:</p>
 <div class="sourceCode" id="cb30"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb30-1"><a href="#cb30-1" aria-hidden="true" tabindex="-1"></a><span class="kw">struct</span> sem_node <span class="op">*</span>_Nullable sem<span class="op">;</span></span></code></pre></div>
-<p>This is the pointer to the semantic information for that node. Semantic analysis happens immediately after parsing and before any of the code-generators run. Importantly code generators never run if semantic analysis reported any errors. Before we get into the shape of the semantic node, we should start with the fundamental unit of type info <code>sem_t</code> which is usually stored in a variable called <code>sem_type</code>.</p>
+<p>This is the pointer to the semantic information for that node. Semantic analysis happens immediately after parsing and before any of the code-generators run. Importantly, code generators never run if semantic analysis reported any errors. Before we get into the shape of the semantic node, we should start with the fundamental unit of type info <code>sem_t</code> which is usually stored in a variable called <code>sem_type</code>.</p>
 <div class="sourceCode" id="cb31"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb31-1"><a href="#cb31-1" aria-hidden="true" tabindex="-1"></a><span class="kw">typedef</span> <span class="dt">uint64_t</span> sem_t<span class="op">;</span></span></code></pre></div>
-<p>The low order bits of a <code>sem_t</code> encode the core type and indeed there is an helper macro to extract the core type from a <code>sem_t</code>.</p>
+<p>The low order bits of a <code>sem_t</code> encode the core type and indeed there is an helper function to extract the core type from a <code>sem_t</code>.</p>
 <div class="sourceCode" id="cb32"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb32-1"><a href="#cb32-1" aria-hidden="true" tabindex="-1"></a><span class="co">// Strips out all the flag bits and gives you the base/core type.</span></span>
 <span id="cb32-2"><a href="#cb32-2" aria-hidden="true" tabindex="-1"></a>cql_noexport sem_t core_type_of<span class="op">(</span>sem_t sem_type<span class="op">)</span> <span class="op">{</span></span>
 <span id="cb32-3"><a href="#cb32-3" aria-hidden="true" tabindex="-1"></a>  <span class="cf">return</span> sem_type <span class="op">&amp;</span> SEM_TYPE_CORE<span class="op">;</span></span>
@@ -884,8 +895,8 @@ AST(or)</code></pre>
 <span id="cb33-15"><a href="#cb33-15" aria-hidden="true" tabindex="-1"></a><span class="pp">#define SEM_TYPE_CORE 0xff      </span><span class="co">// bit mask for the core types</span></span>
 <span id="cb33-16"><a href="#cb33-16" aria-hidden="true" tabindex="-1"></a></span>
 <span id="cb33-17"><a href="#cb33-17" aria-hidden="true" tabindex="-1"></a><span class="pp">#define SEM_TYPE_MAX_UNITARY (SEM_TYPE_OBJECT+1) </span><span class="co">// the last unitary type</span></span></code></pre></div>
-<p>These break into a few categories: * <code>NULL</code> to <code>OBJECT</code> are the “unitary” types, these are the types that a single simple variable can be * a column can be any of these except <code>OBJECT</code> or <code>NULL</code> * the <code>NULL</code> type begins only from the <code>NULL</code> literal which has no type * instance of say a <code>TEXT</code> column might have a <code>NULL</code> value but they are known to be <code>TEXT</code> * <code>STRUCT</code> indicates that the object has many fields, like a table, or a cursor * <code>JOIN</code> indicates that the object is the concatenation of many <code>STRUCT</code> types * e.g. <code>T1 inner join T2</code> is a <code>JOIN</code> type with <code>T1</code> and <code>T2</code> being the parts * a <code>JOIN</code> can be flattend to <code>STRUCT</code> but this is typically not done * the type of a <code>SELECT</code> statement will be a <code>STRUCT</code> representing the columns that were selected which in turn came from the <code>JOIN</code> that was the <code>FROM</code> clause * <code>ERROR</code> indicates that the subtree had an error, it will have been already reported, this generally cascades up the AST to the root * <code>OK</code> indicates that there is no type information but there was no problem, for instance a correct <code>IF</code> statement will resolve to simply <code>OK</code> (no error) * <code>PENDING</code> is used sometimes while a type computation is in progress, it doesn’t appear in the AST but has its own unique value so as to not conflict with any others * <code>REGION</code> used to identify AST fragments that correspond to schema regions (see the Guide for mor info on regions) * <code>CORE</code> is the mask for the core parts, <code>0xf</code> would do the job but for easy reading in the debugger we use <code>0xff</code> * new core types are not added very often, adding a new one is usually a sign that you are doing something wrong</p>
-<p>The core type can be modified by various flags. The flags in principle can be combined in any way but in practice many combinations make no sense. for instance, <code>HAS_DEFAULT</code> is for table columns and <code>CREATE_FUNC</code> is for function declarations. There is no one object that could require both of these.</p>
+<p>These break into a few categories: * <code>NULL</code> to <code>OBJECT</code> are the “unitary” types, these are the types that a single simple variable can be * a column can be any of these except <code>OBJECT</code> or <code>NULL</code> * the <code>NULL</code> type comes only from the <code>NULL</code> literal which has no type * instances of say a <code>TEXT</code> column might have a <code>NULL</code> value but they are known to be <code>TEXT</code> * <code>STRUCT</code> indicates that the object has many fields, like a table, or a cursor * <code>JOIN</code> indicates that the object is the concatenation of many <code>STRUCT</code> types * e.g. <code>T1 inner join T2</code> is a <code>JOIN</code> type with <code>T1</code> and <code>T2</code> being the parts * a <code>JOIN</code> could be flattened to <code>STRUCT</code>, but this is typically not done * the type of a <code>SELECT</code> statement will be a <code>STRUCT</code> representing the expressions that were selected * those expressions in turn used columns from the <code>JOIN</code> that was the <code>FROM</code> clause * <code>ERROR</code> indicates that the subtree had an error * the error will have been already reported * the error type generally cascades up the AST to the root * <code>OK</code> indicates that there is no type information but there was no problem * e.g. a correct <code>IF</code> statement will resolve to simply <code>OK</code> (no error) * <code>PENDING</code> is used sometimes while a type computation is in progress * this type doesn’t appear in the AST, but has its own unique value so as to not conflict with any others * <code>REGION</code> is used to identify AST fragments that correspond to schema regions * see <a href="https://cgsql.dev/cql-guide/ch10">Chapter 10</a> of the Guide for more information on regions * <code>CORE</code> is the mask for the core parts, <code>0xf</code> would do the job but for easy reading in the debugger we use <code>0xff</code> * new core types are not added very often, adding a new one is usually a sign that you are doing something wrong</p>
+<p>The core type can be modified by various flags. The flags in principle can be combined in any way but in practice many combinations make no sense. For instance, <code>HAS_DEFAULT</code> is for table columns and <code>CREATE_FUNC</code> is for function declarations. There is no one object that could require both of these.</p>
 <p>The full list as of this writing is as follows:</p>
 <div class="sourceCode" id="cb34"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb34-1"><a href="#cb34-1" aria-hidden="true" tabindex="-1"></a><span class="pp">#define SEM_TYPE_NOTNULL               _64(0x0100) </span><span class="co">// set if and only if null is not possible</span></span>
 <span id="cb34-2"><a href="#cb34-2" aria-hidden="true" tabindex="-1"></a><span class="pp">#define SEM_TYPE_HAS_DEFAULT           _64(0x0200) </span><span class="co">// set for table columns with a default</span></span>
@@ -916,21 +927,23 @@ AST(or)</code></pre>
 <span id="cb34-27"><a href="#cb34-27" aria-hidden="true" tabindex="-1"></a><span class="pp">#define SEM_TYPE_TVF              _64(0x400000000) </span><span class="co">// set if and only table node is a table valued function</span></span>
 <span id="cb34-28"><a href="#cb34-28" aria-hidden="true" tabindex="-1"></a><span class="pp">#define SEM_TYPE_IMPLICIT         _64(0x800000000) </span><span class="co">// set if and only the variable was declare implicitly (via declare out)</span></span>
 <span id="cb34-29"><a href="#cb34-29" aria-hidden="true" tabindex="-1"></a><span class="pp">#define SEM_TYPE_CALLS_OUT_UNION _64(0x1000000000) </span><span class="co">// set if proc calls an out union proc for</span></span></code></pre></div>
-<p>Going over the meaning of all of the above is again beyond the scope of this document, some of them are very specialized and essentially the validation requires a bit of storage in the tree to do its job so that storage is provided with a bit. However two flag bits are especially important and are computed almost everywhere <code>sem_t</code> is used. These are <code>SEM_TYPE_NOTNULL</code> and <code>SEM_TYPE_SENSITIVE</code>.</p>
+<p>Note: <code>_64(x)</code> expands to either a trailing <code>L</code> or a trailing <code>LL</code> depending on the bitness of the compiler, whichever yields an <code>int64_t</code>.</p>
+<p>Going over the meaning of all of the above is again beyond the scope of this document; some of the flags are very specialized and essentially the validation just requires a bit of storage in the tree to do its job so that storage is provided with a flag. However two flag bits are especially important and are computed almost everywhere <code>sem_t</code> is used. These are <code>SEM_TYPE_NOTNULL</code> and <code>SEM_TYPE_SENSITIVE</code>.</p>
 <ul>
-<li><code>SEM_TYPE_NOTNULL</code> indicates that the marked item is known to be <code>NOT NULL</code>, probably because it was declared as such or directly derived from a not null item
+<li><code>SEM_TYPE_NOTNULL</code> indicates that the marked item is known to be <code>NOT NULL</code>, probably because it was declared as such, or directly derived from a not null item
 <ul>
-<li>Typically when two operands are combined both must be marked <code>NOT NULL</code> for the result to still be NOT NULL (there are exceptions like <code>COALESCE</code>)</li>
-<li>Values that might be null cannot be assigned to targets that must be not null</li>
+<li>Typically when two operands are combined both must be marked <code>NOT NULL</code> for the result to still be <code>NOT NULL</code> (there are exceptions like <code>COALESCE</code>)</li>
+<li>Values that might be null cannot be assigned to targets that must not be null</li>
 </ul></li>
 <li><code>SEM_TYPE_SENSITIVE</code> indicates that the marked item is some kind of PII or other sensitive data.
 <ul>
-<li>Any time a sensitive item is combined with some other piece of data the result is a new sensitive piece of data, there are very few ways to “get rid” of the sensitive bit. It corresponds to the presence of <code>@sensitive</code> in the data type declaration.</li>
-<li>Values that are sensitive cannot be assigned to targets that are not also marked sensitive</li>
+<li>Any time a sensitive operand is combined with another operand the resulting type is sensitive</li>
+<li>There are very few ways to “get rid” of the sensitive bit – it corresponds to the presence of <code>@sensitive</code> in the data type declaration.</li>
+<li>Values that are sensitive cannot be assigned to targets that are not marked sensitive</li>
 </ul></li>
 </ul>
-<p>The semantic node <code>sem_node</code> carries all the possible semantic info we might need, the <code>sem_type</code> holds the flags above and tells us how to interpret it. There are many fields, we’ll talk about some of the most important ones here to give you a sense of how things hang together.</p>
-<p>Note that <code>CSTR</code> is simply an alias for <code>const char *</code>.</p>
+<p>The semantic node <code>sem_node</code> carries all the possible semantic info we might need, the <code>sem_type</code> holds the flags above and tells us how to interpret the rest of the node. There are many fields, we’ll talk about some of the most important ones here to give you a sense of how things hang together.</p>
+<p>Note that <code>CSTR</code> is simply an alias for <code>const char *</code>. <code>CSTR</code> is used extensively in the codebase for brevity.</p>
 <div class="sourceCode" id="cb35"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb35-1"><a href="#cb35-1" aria-hidden="true" tabindex="-1"></a><span class="kw">typedef</span> <span class="kw">struct</span> sem_node <span class="op">{</span></span>
 <span id="cb35-2"><a href="#cb35-2" aria-hidden="true" tabindex="-1"></a>  sem_t sem_type<span class="op">;</span>                   <span class="co">// core type plus flags</span></span>
 <span id="cb35-3"><a href="#cb35-3" aria-hidden="true" tabindex="-1"></a>  CSTR name<span class="op">;</span>                        <span class="co">// for named expressions in select columns etc.</span></span>
@@ -951,17 +964,18 @@ AST(or)</code></pre>
 <li><code>sem_type</code> : already discussed above, this tells you how to interpret everything else</li>
 <li><code>name</code> : variables, columns, etc. have a canonical name, when a name case-insenstively resolves, the canonical name is stored here
 <ul>
-<li>typically you want to emit the canonical variable name (e.g. <code>FoO</code> and <code>fOO</code> might both resolve to <code>foo</code> if that is how it was declared)</li>
+<li>typically later passes emit the canonical variable name everywhere</li>
+<li>e.g. <code>FoO</code> and <code>fOO</code> might both resolve to an object declared as <code>foo</code>, we always emit <code>foo</code> in codegen</li>
 </ul></li>
 <li><code>kind</code> : in CQL any type can be discriminated as in <code>declare foo real&lt;meters&gt;</code>, the kind here is <code>meters</code>
 <ul>
-<li>expressions of the same core type (e.g. <code>real</code>) are incompatible if they have a <code>kind</code> and the <code>kind</code> does not match</li>
-<li>e.g. you can’t assign if you have <code>bar real&lt;liters&gt;</code> then <code>set foo := bar;</code> is an error even though both are <code>real</code>.</li>
+<li>two expressions of the same core type (e.g. <code>real</code>) are incompatible if they have a <code>kind</code> and the <code>kind</code> does not match</li>
+<li>e.g. if you have <code>bar real&lt;liters&gt;</code> then <code>set foo := bar;</code> is an error even though both are <code>real</code> because <code>foo</code> above is <code>real&lt;meters&gt;</code></li>
 </ul></li>
 <li><code>sptr</code> : if the item’s core type is <code>SEM_TYPE_STRUCT</code> then this is populated, see below</li>
 <li><code>jptr</code> : if the item’s core type is <code>SEM_TYPE_JOIN</code> then this is populated, see below</li>
 </ul>
-<p>If the object is a structure type then this is simply an array of names, kinds, and semantic types. In fact the semantic types will be all be unitary possibly modified by <code>NOT_NULL</code> or <code>SENSITIVE</code> but none of the other flags apply. A single <code>sptr</code> directly corresponds to the notion of a <code>shape</code> in the analyzer. Shapes come from anything that looks like a table, such as a cursor, or the result of a <code>SELECT</code> statement.</p>
+<p>If the object is a structure type then this is simply an array of names, kinds, and semantic types. In fact the semantic types will be all be unitary, possibly modified by <code>NOT_NULL</code> or <code>SENSITIVE</code> but none of the other flags apply. A single <code>sptr</code> directly corresponds to the notion of a “shape” in the analyzer. Shapes come from anything that looks like a table, such as a cursor, or the result of a <code>SELECT</code> statement.</p>
 <div class="sourceCode" id="cb36"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb36-1"><a href="#cb36-1" aria-hidden="true" tabindex="-1"></a><span class="co">// for tables and views and the result of a select</span></span>
 <span id="cb36-2"><a href="#cb36-2" aria-hidden="true" tabindex="-1"></a></span>
 <span id="cb36-3"><a href="#cb36-3" aria-hidden="true" tabindex="-1"></a><span class="kw">typedef</span> <span class="kw">struct</span> sem_struct <span class="op">{</span></span>
@@ -982,7 +996,7 @@ AST(or)</code></pre>
 <span id="cb37-8"><a href="#cb37-8" aria-hidden="true" tabindex="-1"></a><span class="op">}</span> sem_join<span class="op">;</span></span></code></pre></div>
 <p>With these building blocks we can represent the type of anything in the CQL language.</p>
 <h3 id="initiating-semantic-analysis">Initiating Semantic Analysis</h3>
-<p>The semantic analysis pass runs much the same way as the AST emitter. In <code>sem.c</code> there is the essential function <code>sem_main</code>. It suffices to call <code>sem_main</code> on the root of your AST, that is expect to be a <code>stmt_list</code> node.</p>
+<p>The semantic analysis pass runs much the same way as the AST emitter. In <code>sem.c</code> there is the essential function <code>sem_main</code>. It suffices to call <code>sem_main</code> on the root of the AST. That root node is expected to be a <code>stmt_list</code> node.</p>
 <div class="sourceCode" id="cb38"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb38-1"><a href="#cb38-1" aria-hidden="true" tabindex="-1"></a><span class="co">// This method loads up the global symbol tables in either empty state or</span></span>
 <span id="cb38-2"><a href="#cb38-2" aria-hidden="true" tabindex="-1"></a><span class="co">// with the appropriate tokens ready to go.  Using our own symbol tables for</span></span>
 <span id="cb38-3"><a href="#cb38-3" aria-hidden="true" tabindex="-1"></a><span class="co">// dispatch saves us a lot of if/else string comparison verbosity.</span></span>
@@ -992,8 +1006,8 @@ AST(or)</code></pre>
 <span id="cb38-7"><a href="#cb38-7" aria-hidden="true" tabindex="-1"></a>  eval_init<span class="op">();</span></span>
 <span id="cb38-8"><a href="#cb38-8" aria-hidden="true" tabindex="-1"></a>  <span class="op">...</span></span>
 <span id="cb38-9"><a href="#cb38-9" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span></code></pre></div>
-<p>As you can see, <code>sem_main</code> begins by reseting all the state. You can of course do this yourself after calling <code>sem_main</code> (when you’re done with the results).</p>
-<p><code>sem_main</code> sets a variety of useful and public global variables that describe the results of the analysis. The ones in <code>sem.h</code> are part of the contract and you should feel free to use them in a downstream code-generator. Other items are internal and should be avoided. These are typically defined statically in <code>sem.c</code>.</p>
+<p>As you can see, <code>sem_main</code> begins by reseting all the global state. You can of course do this yourself after calling <code>sem_main</code> (when you’re done with the results).</p>
+<p><code>sem_main</code> sets a variety of useful and public global variables that describe the results of the analysis. The ones in <code>sem.h</code> are part of the contract and you should feel free to use them in a downstream code-generator. Other items are internal and should be avoided. The internal items are typically defined statically in <code>sem.c</code>. The essential outputs will be described in the last section of this part.</p>
 <p>The cleanup has this structure:</p>
 <div class="sourceCode" id="cb39"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb39-1"><a href="#cb39-1" aria-hidden="true" tabindex="-1"></a><span class="co">// This method frees all the global state of the semantic analyzer</span></span>
 <span id="cb39-2"><a href="#cb39-2" aria-hidden="true" tabindex="-1"></a>cql_noexport <span class="dt">void</span> sem_cleanup<span class="op">()</span> <span class="op">{</span></span>
@@ -1014,7 +1028,8 @@ AST(or)</code></pre>
 <span id="cb39-17"><a href="#cb39-17" aria-hidden="true" tabindex="-1"></a>  all_ad_hoc_list <span class="op">=</span> NULL<span class="op">;</span></span>
 <span id="cb39-18"><a href="#cb39-18" aria-hidden="true" tabindex="-1"></a>  all_functions_list <span class="op">=</span> NULL<span class="op">;</span></span>
 <span id="cb39-19"><a href="#cb39-19" aria-hidden="true" tabindex="-1"></a>    <span class="op">...</span></span></code></pre></div>
-<p><code>sem_main</code> of course has to walk the AST and it does so in much the same way as we saw in <code>gen_sql.c</code> there are a set of symbol tables whose key is an ast type and whose value is a function plus arguments to dispatch (effectively a lambda). The semantic analyzer doesn’t have to think about things like “should I emit parentheses” so the signature of each type of lambda can be quite a bit simpler. We’ll go over each kind with some examples.</p>
+<p>This basically deallocates everything and resets all the globals to <code>NULL</code>.</p>
+<p><code>sem_main</code> of course has to walk the AST and it does so in much the same way as we saw in <code>gen_sql.c</code>. There is a series of symbol tables whose key is an AST type and whose value is a function plus arguments to dispatch (effectively a lambda). The semantic analyzer doesn’t have to think about things like “should I emit parentheses” so the signature of each type of lambda can be quite a bit simpler. We’ll go over each kind with some examples.</p>
 <p>First we have the non-sql statements, these are basic flow control or other things that SQLite will never see directly.</p>
 <div class="sourceCode" id="cb40"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb40-1"><a href="#cb40-1" aria-hidden="true" tabindex="-1"></a>  symtab <span class="op">*</span>syms <span class="op">=</span> non_sql_stmts<span class="op">;</span></span>
 <span id="cb40-2"><a href="#cb40-2" aria-hidden="true" tabindex="-1"></a></span>
@@ -1023,8 +1038,8 @@ AST(or)</code></pre>
 <span id="cb40-5"><a href="#cb40-5" aria-hidden="true" tabindex="-1"></a>  STMT_INIT<span class="op">(</span>switch_stmt<span class="op">);</span></span>
 <span id="cb40-6"><a href="#cb40-6" aria-hidden="true" tabindex="-1"></a>  STMT_INIT<span class="op">(</span>leave_stmt<span class="op">);</span></span>
 <span id="cb40-7"><a href="#cb40-7" aria-hidden="true" tabindex="-1"></a>  <span class="op">...</span></span></code></pre></div>
-<p>Here <code>STMT_INIT</code> creates a binding between (e.g.) the AST type <code>if_stmt</code> and the function <code>sem_if_stmt</code>. This lets us dispatch any part of the AST directly.</p>
-<p>Next we have the SQL statements. These get analyzed in the same way as the others, and with functions that have the same signature, however, if you use one of these it means that procedure that contained this statement must get a database connection in order to run. This changes its signature and causes the <code>SEM_TYPE_DML_PROC</code> flag bit to be set on it.</p>
+<p>Here <code>STMT_INIT</code> creates a binding between (e.g.) the AST type <code>if_stmt</code> and the function <code>sem_if_stmt</code>. This lets us dispatch any part of the AST to its handler directly.</p>
+<p>Next we have the SQL statements. These get analyzed in the same way as the others, and with functions that have the same signature, however, if you use one of these it means that procedure that contained this statement must get a database connection in order to run. Use of the database will require the procedure’s signature to change; this is recorded by the setting the <code>SEM_TYPE_DML_PROC</code> flag bit to be set on the procedures AST node.</p>
 <div class="sourceCode" id="cb41"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb41-1"><a href="#cb41-1" aria-hidden="true" tabindex="-1"></a>  syms <span class="op">=</span> sql_stmts<span class="op">;</span></span>
 <span id="cb41-2"><a href="#cb41-2" aria-hidden="true" tabindex="-1"></a></span>
 <span id="cb41-3"><a href="#cb41-3" aria-hidden="true" tabindex="-1"></a>  STMT_INIT<span class="op">(</span>create_table_stmt<span class="op">);</span></span>
@@ -1036,8 +1051,8 @@ AST(or)</code></pre>
 <span id="cb41-9"><a href="#cb41-9" aria-hidden="true" tabindex="-1"></a>  STMT_INIT<span class="op">(</span>update_stmt<span class="op">);</span></span>
 <span id="cb41-10"><a href="#cb41-10" aria-hidden="true" tabindex="-1"></a>  STMT_INIT<span class="op">(</span>insert_stmt<span class="op">);</span></span>
 <span id="cb41-11"><a href="#cb41-11" aria-hidden="true" tabindex="-1"></a>  <span class="op">...</span></span></code></pre></div>
-<p>Again <code>STMT_INIT</code> creates a binding between (e.g.) the AST type <code>delete_stmt</code> and the function <code>sem_delete_stmt</code>. This lets us dispatch any part of the AST directly.</p>
-<p>Next we have expression types, these are set up with <code>EXPR_INIT</code>. Many of the operators require exactly the same kinds of verification so in order to be able to share the code, the expression analysis functions get an extra argument for the operator in question. Typically the string of the operator is only needed so make a good quality error message and validation is otherwise identical. Here are some samples…</p>
+<p>Again <code>STMT_INIT</code> creates a binding between (e.g.) the AST type <code>delete_stmt</code> and the function <code>sem_delete_stmt</code> so we can dispatch to the handler.</p>
+<p>Next we have expression types, these are set up with <code>EXPR_INIT</code>. Many of the operators require exactly the same kinds of verification, so in order to be able to share the code, the expression analysis functions get an extra argument for the operator in question. Typically the string of the operator is only needed to make a good quality error message with validation being otherwise identical. Here are some samples…</p>
 <div class="sourceCode" id="cb42"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb42-1"><a href="#cb42-1" aria-hidden="true" tabindex="-1"></a>  EXPR_INIT<span class="op">(</span>num<span class="op">,</span> sem_expr_num<span class="op">,</span> <span class="st">&quot;NUM&quot;</span><span class="op">);</span></span>
 <span id="cb42-2"><a href="#cb42-2" aria-hidden="true" tabindex="-1"></a>  EXPR_INIT<span class="op">(</span>str<span class="op">,</span> sem_expr_str<span class="op">,</span> <span class="st">&quot;STR&quot;</span><span class="op">);</span></span>
 <span id="cb42-3"><a href="#cb42-3" aria-hidden="true" tabindex="-1"></a>  EXPR_INIT<span class="op">(</span>blob<span class="op">,</span> sem_expr_blob<span class="op">,</span> <span class="st">&quot;BLB&quot;</span><span class="op">);</span></span>
@@ -1050,8 +1065,8 @@ AST(or)</code></pre>
 <span id="cb42-10"><a href="#cb42-10" aria-hidden="true" tabindex="-1"></a>  EXPR_INIT<span class="op">(</span>is_true<span class="op">,</span> sem_unary_is_true_or_false<span class="op">,</span> <span class="st">&quot;IS TRUE&quot;</span><span class="op">);</span></span>
 <span id="cb42-11"><a href="#cb42-11" aria-hidden="true" tabindex="-1"></a>  EXPR_INIT<span class="op">(</span>tilde<span class="op">,</span> sem_unary_integer_math<span class="op">,</span> <span class="st">&quot;~&quot;</span><span class="op">);</span></span>
 <span id="cb42-12"><a href="#cb42-12" aria-hidden="true" tabindex="-1"></a>  EXPR_INIT<span class="op">(</span>uminus<span class="op">,</span> sem_unary_math<span class="op">,</span> <span class="st">&quot;-&quot;</span><span class="op">);</span></span></code></pre></div>
-<p>Looking at the very first entry as an example we see that <code>EXPR_INIT</code> creates a mapping between the AST type <code>num</code> and the analysis function <code>sem_expr_num</code> and that function will get the text <code>"NUM"</code> as an extra argument.</p>
-<p>Let’s quickly go over this list as these are the most important analyzers</p>
+<p>Looking at the very first entry as an example, we see that <code>EXPR_INIT</code> creates a mapping between the AST type <code>num</code> and the analysis function <code>sem_expr_num</code> and that function will get the text <code>"NUM"</code> as an extra argument. As it happens <code>sem_expr_num</code> doesn’t need the extra argument, but <code>sem_binary_math</code> certainly needs the <code>"*"</code> as that function handles a large number of binary operators.</p>
+<p>Let’s quickly go over this list as these are the most important analyzers:</p>
 <ul>
 <li><code>sem_expr_num</code> : analyzes any numeric constant</li>
 <li><code>sem_expr_str</code> : analyzes any string literal or identifier</li>
@@ -1063,21 +1078,21 @@ AST(or)</code></pre>
 <li><code>sem_binary_integer_math</code> : analyzes any binary math operator where the operands must be integers like ‘%’ or ‘|’</li>
 <li><code>sem_unary_logical</code> : analyzes any unary logical operator (the result is a bool), this is really only <code>NOT</code></li>
 <li><code>sem_unary_is_true_or_false</code> : analyzes any of the <code>IS TRUE</code>, <code>IS FALSE</code>, family of postfix unary operators</li>
-<li><code>sem_unary_integer_math</code> : any unary operator where the operand must be an integer, this is really only <code>~</code></li>
-<li><code>sem_unary_math</code> : any math unary, presently only unary negation (but in the future unary <code>+</code> too)</li>
+<li><code>sem_unary_integer_math</code> : analyzes any unary operator where the operand must be an integer, this is really only <code>~</code></li>
+<li><code>sem_unary_math</code> : analyzes any any math unary operator, presently only negation (but in the future unary <code>+</code> too)</li>
 </ul>
-<p>The final plentiful group of associations are for builtin functions, like these.</p>
+<p>The last group of normal associations are for builtin functions, like these:</p>
 <div class="sourceCode" id="cb43"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb43-1"><a href="#cb43-1" aria-hidden="true" tabindex="-1"></a>  FUNC_INIT<span class="op">(</span>changes<span class="op">);</span></span>
 <span id="cb43-2"><a href="#cb43-2" aria-hidden="true" tabindex="-1"></a>  FUNC_INIT<span class="op">(</span>printf<span class="op">);</span></span>
 <span id="cb43-3"><a href="#cb43-3" aria-hidden="true" tabindex="-1"></a>  FUNC_INIT<span class="op">(</span>strftime<span class="op">);</span></span>
 <span id="cb43-4"><a href="#cb43-4" aria-hidden="true" tabindex="-1"></a>  FUNC_INIT<span class="op">(</span>date<span class="op">);</span></span>
 <span id="cb43-5"><a href="#cb43-5" aria-hidden="true" tabindex="-1"></a>  FUNC_INIT<span class="op">(</span>time<span class="op">);</span></span></code></pre></div>
-<p>Each of these is dispatched when a function call is found in the tree. By way of example <code>FUNC_INIT(changes)</code> causes the <code>changes</code> function to map to <code>sem__func_changes</code>.</p>
-<p>There are a few other similar macros for more exotic cases but the general pattern should be clear now. We these in place it’s very easy to traverse arbitary statement lists and arbitary expressions with sub expressions and have the correct function be called without having large <code>switch</code> blocks all over.</p>
+<p>Each of these is dispatched when a function call is found in the tree. By way of example <code>FUNC_INIT(changes)</code> causes the <code>changes</code> function to map to <code>sem_func_changes</code> for validation.</p>
+<p>There are a few other similar macros for more exotic cases but the general pattern should be clear now. With these in place it’s very easy to traverse arbitary statement lists and arbitary expressions with sub expressions and have the correct function invoked without having large <code>switch</code> blocks all over.</p>
 <h3 id="semantic-errors">Semantic Errors</h3>
-<p>Some of the following examples will show the handling of semantic errors more precisely but the theory is pretty simple. Each of these analyzers that has been registered is responsible for putting an appropriate <code>sem_node</code> into the AST it was invoked on. The caller will look to see if that <code>sem_node</code> is of type <code>SEM_TYPE_ERROR</code> using <code>is_error(ast)</code>. If it is the caller will mark its own AST as errant using <code>record_error(ast)</code> and this continues all the way up the tree. The net of this is that wherever you begin semantic analysis you can know if there were any problems by checking for an error at the top of the tree you provided.</p>
-<p>At the point of the initial error, the analyzer is expected to also call <code>report_error</code> providing a suitable message. This will be logged to stderr. In test mode it is also stored in the AST so that verification steps can confirm that errors were reported at exactly the right place.</p>
-<p>If there is no error, then either a suitable <code>sem_node</code> is created or else at minimum <code>record_ok(ast)</code> is used to place the shared “OK” type on the node. The OK type indicates no type information but no errors either. “OK” is helpful for statements that don’t involve expressions like <code>DROP TABLE Foo</code>.</p>
+<p>Some of the following examples will show the handling of semantic errors more precisely but the theory is pretty simple. Each of the analyzers that has been registered is responsible for putting an appropriate <code>sem_node</code> into the AST it is invoked on. The caller will look to see if that <code>sem_node</code> is of type <code>SEM_TYPE_ERROR</code> using <code>is_error(ast)</code>. If it is, the caller will mark its own AST as errant using <code>record_error(ast)</code> and this continues all the way up the tree. The net of this is that wherever you begin semantic analysis, you can know if there were any problems by checking for an error at the top of the tree you provided.</p>
+<p>At the point of the initial error, the analyzer is expected to also call <code>report_error</code> providing a suitable message. This will be logged to <code>stderr</code>. In test mode it is also stored in the AST so that verification steps can confirm that errors were reported at exactly the right place.</p>
+<p>If there are no errors, then a suitable <code>sem_node</code> is created for the resulting type or else, at minimum, <code>record_ok(ast)</code> is used to place the shared “OK” type on the node. The “OK” type indicates no type information, but no errors either. “OK” is helpful for statements that don’t involve expressions like <code>DROP TABLE Foo</code>.</p>
 <h3 id="the-primitive-types">The Primitive Types</h3>
 <p>Perhaps the simplest analysis of all happens at the leaves of the AST. By way of example, here is the code for expression nodes of type <code>num</code>, the numeric literals.</p>
 <div class="sourceCode" id="cb44"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb44-1"><a href="#cb44-1" aria-hidden="true" tabindex="-1"></a><span class="co">// Expression type for numeric primitives</span></span>
@@ -1104,7 +1119,7 @@ AST(or)</code></pre>
 <span id="cb44-22"><a href="#cb44-22" aria-hidden="true" tabindex="-1"></a>    <span class="cf">break</span><span class="op">;</span></span>
 <span id="cb44-23"><a href="#cb44-23" aria-hidden="true" tabindex="-1"></a>  <span class="op">}</span></span>
 <span id="cb44-24"><a href="#cb44-24" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span></code></pre></div>
-<p>As you can see the code simply looks at the AST node, confirming first that it is a <code>num</code> node. Then it extract the <code>num_type</code>. <code>ast-&gt;sem</code> is set to a semantic node of the matching type adding in <code>SEM_TYPE_NOTNULL</code> because literals are never null.</p>
+<p>As you can see the code simply looks at the AST node, confirming first that it is a <code>num</code> node. Then it extracts the <code>num_type</code>. Then <code>ast-&gt;sem</code> is set to a semantic node of the matching type adding in <code>SEM_TYPE_NOTNULL</code> because literals are never null.</p>
 <p>The <code>new_sem</code> function is used to make an empty <code>sem_node</code> with the <code>sem_type</code> filled in as specified. Nothing can go wrong creating a literal so there are no failure modes.</p>
 <p>It doesn’t get much simpler unless maybe…</p>
 <div class="sourceCode" id="cb45"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb45-1"><a href="#cb45-1" aria-hidden="true" tabindex="-1"></a><span class="co">// Expression type for constant NULL</span></span>
@@ -1113,8 +1128,10 @@ AST(or)</code></pre>
 <span id="cb45-4"><a href="#cb45-4" aria-hidden="true" tabindex="-1"></a>  <span class="co">// null literal</span></span>
 <span id="cb45-5"><a href="#cb45-5" aria-hidden="true" tabindex="-1"></a>  ast<span class="op">-&gt;</span>sem <span class="op">=</span> new_sem<span class="op">(</span>SEM_TYPE_NULL<span class="op">);</span></span>
 <span id="cb45-6"><a href="#cb45-6" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span></code></pre></div>
+<p>It’s hard to get simpiler than doing semantic analysis of the <code>NULL</code> literal. Its code should be clear with no further explaination needed.</p>
 <h3 id="unary-operators">Unary Operators</h3>
-<p>Let’s dive in to a simple case – the unary operators. There are comparatively few and there isn’t much code required to handle them all.</p>
+<p>Let’s dive in to a simple case that does require some analysis – the unary operators. There are comparatively few and there isn’t much code required to handle them all.</p>
+<p>Here’s the code for the unary math operators:</p>
 <div class="sourceCode" id="cb46"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb46-1"><a href="#cb46-1" aria-hidden="true" tabindex="-1"></a><span class="co">// The only unary math operators are &#39;-&#39; and &#39;~&#39;</span></span>
 <span id="cb46-2"><a href="#cb46-2" aria-hidden="true" tabindex="-1"></a><span class="co">// Reference types are not allowed</span></span>
 <span id="cb46-3"><a href="#cb46-3" aria-hidden="true" tabindex="-1"></a><span class="dt">static</span> <span class="dt">void</span> sem_unary_math<span class="op">(</span>ast_node <span class="op">*</span>ast<span class="op">,</span> CSTR op<span class="op">)</span> <span class="op">{</span></span>
@@ -1143,7 +1160,7 @@ AST(or)</code></pre>
 <span id="cb46-26"><a href="#cb46-26" aria-hidden="true" tabindex="-1"></a>  <span class="co">// hence ast-&gt;sem-&gt;name = ast-&gt;left-&gt;sem-&gt;name is WRONG here and it is not missing on accident</span></span>
 <span id="cb46-27"><a href="#cb46-27" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span></code></pre></div>
 <p><em>Unary Prep</em></p>
-<p>OK already we need to pause, there is a “prep” pattern here common to most of the shared operators. This takes care of most of the normal error handling which is the same for all the unary operators. The same pattern happens in binary operators. Let’s take a look at that function.</p>
+<p>OK already we need to pause, there is a “prep” pattern here common to most of the shared operators that we should discuss. The prep step takes care of most of the normal error handling which is the same for all the unary operators and same pattern happens in binary operators. Let’s take a look at <code>sem_unary_prep</code>.</p>
 <div class="sourceCode" id="cb47"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb47-1"><a href="#cb47-1" aria-hidden="true" tabindex="-1"></a><span class="co">// The unary operators all have a similar prep to the binary.  We need</span></span>
 <span id="cb47-2"><a href="#cb47-2" aria-hidden="true" tabindex="-1"></a><span class="co">// to visit the left side (it&#39;s always the left node even if the operator goes on the right)</span></span>
 <span id="cb47-3"><a href="#cb47-3" aria-hidden="true" tabindex="-1"></a><span class="co">// if that&#39;s ok then we need the combined_flags and core type.  There is only</span></span>
@@ -1170,39 +1187,43 @@ AST(or)</code></pre>
 <span id="cb47-24"><a href="#cb47-24" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span></code></pre></div>
 <p>Reviewing the steps:</p>
 <ul>
-<li>first evaluate the operand, it will be in <code>ast-&gt;left</code></li>
-<li>if that’s an error, just return the error code from the prep steps</li>
-<li>now that it’s not an error, pull the core type out of the operand</li>
-<li>pull the not nullable and sensitive flag bits out of the operand</li>
-<li>return a boolean indicating the presence of an error or not for convenience</li>
+<li>first we analyze the operand, it will be in <code>ast-&gt;left</code></li>
+<li>if that’s an error, we just return the error code from the prep steps</li>
+<li>now that it’s not an error, we pull the core type out of the operand</li>
+<li>then we pull the not nullable and sensitive flag bits out of the operand</li>
+<li>finally return a boolean indicating the presence of an error (or not) for convenience</li>
 </ul>
-<p>This is useful setup for all the unary operators, and as we’ll see, the binary operator case has a similar prep step.</p>
+<p>This is useful setup for all the unary operators, and as we’ll see, the binary operators have a similar prep step.</p>
 <p><em>Back to Unary Processing</em></p>
-<p>Looking at the overall step we see:</p>
+<p>Looking at the overall steps we see:</p>
 <ul>
 <li><code>sem_unary_prep</code> : verifies that the operand is not an error, and gets its core type and flag bits</li>
-<li><code>sem_validate_numeric</code> : verifies that the operand is a numeric type</li>
+<li><code>sem_validate_numeric</code> : verifies that the operand is a numeric type
+<ul>
+<li>recall these are the math unary operators, so the operand must be numeric</li>
+</ul></li>
 <li><code>sem_combine_types</code> : creates the smallest type that holds two compatible types
 <ul>
-<li>by combining with integer not null we ensure that the resulting type is at least as big as an integer</li>
-<li>if the argument is of type <code>long</code> or <code>real</code> then it will be the bigger type and the resulting type will be <code>long</code> or <code>real</code></li>
+<li>by combining with “integer not null” we ensure that the resulting type is at least as big as an integer</li>
+<li>if the argument is of type <code>long</code> or <code>real</code> then it will be the bigger type and the resulting type will be <code>long</code> or <code>real</code> as appropriate</li>
 <li>in short, <code>bool</code> is promoted to <code>int</code>, everything else stays the same</li>
 <li><code>sem_combine_types</code> also combines the nullability and sensitivity appropriately</li>
 </ul></li>
-<li>a new <code>sem_node</code> is created of the combined type
+<li>a new <code>sem_node</code> of the combined type is created
 <ul>
-<li>the type kind of the operand is preserved (e.g. the <code>meters</code> in <code>real&lt;meters&gt;</code>)</li>
+<li>the type “kind” of the operand is preserved (e.g. the <code>meters</code> in <code>real&lt;meters&gt;</code>)</li>
 <li>any column alias or variable name is not preserved, the value is now anonymous</li>
 </ul></li>
 </ul>
-<p>These primitives are designed to combine well, for instance, consider <code>sem_unary_integer_math</code>, the steps are</p>
+<p>These primitives are designed to combine well, for instance, consider <code>sem_unary_integer_math</code></p>
 <div class="sourceCode" id="cb48"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb48-1"><a href="#cb48-1" aria-hidden="true" tabindex="-1"></a><span class="dt">static</span> <span class="dt">void</span> sem_unary_integer_math<span class="op">(</span>ast_node <span class="op">*</span>ast<span class="op">,</span> CSTR op<span class="op">)</span> <span class="op">{</span></span>
 <span id="cb48-2"><a href="#cb48-2" aria-hidden="true" tabindex="-1"></a>  sem_unary_math<span class="op">(</span>ast<span class="op">,</span> op<span class="op">);</span></span>
 <span id="cb48-3"><a href="#cb48-3" aria-hidden="true" tabindex="-1"></a>  sem_reject_real<span class="op">(</span>ast<span class="op">,</span> op<span class="op">);</span></span>
 <span id="cb48-4"><a href="#cb48-4" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span></code></pre></div>
+<p>The steps are:</p>
 <ul>
-<li><code>sem_unary_math</code> : do all the above</li>
-<li><code>sem_reject_real</code> : report/record an error if the type is <code>real</code> otherwise do nothing</li>
+<li><code>sem_unary_math</code> : do the sequence we just discussed</li>
+<li><code>sem_reject_real</code> : report/record an error if the result type is <code>real</code> otherwise do nothing</li>
 </ul>
 <p>Note that in all cases the <code>op</code> string simply gets pushed down to the place where the errors happen. Let’s take a quick look at one of the sources of errors in the above. Here’s the numeric validator:</p>
 <div class="sourceCode" id="cb49"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb49-1"><a href="#cb49-1" aria-hidden="true" tabindex="-1"></a><span class="dt">static</span> bool_t sem_validate_numeric<span class="op">(</span>ast_node <span class="op">*</span>ast<span class="op">,</span> sem_t core_type<span class="op">,</span> CSTR op<span class="op">)</span> <span class="op">{</span></span>
@@ -1226,7 +1247,7 @@ AST(or)</code></pre>
 <span id="cb49-19"><a href="#cb49-19" aria-hidden="true" tabindex="-1"></a></span>
 <span id="cb49-20"><a href="#cb49-20" aria-hidden="true" tabindex="-1"></a>  <span class="cf">return</span> true<span class="op">;</span></span>
 <span id="cb49-21"><a href="#cb49-21" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span></code></pre></div>
-<p>This is pretty much dumb as rocks. The non-numeric types are blob, object, and text. There is a custom error for each type (it could have been shared but specific error messages seem to help users). This code doesn’t know it’s context, but all it needs is <code>op</code> to tell it what the numeric-only operator was and it can produce a nice error message. It leaves an error in the AST using <code>record_error</code> and so its caller can simply <code>return</code> if anything goes wrong.</p>
+<p>That function is pretty much dumb as rocks. The non-numeric types are blob, object, and text. There is a custom error for each type (it could have been shared but specific error messages seem to help users). This code doesn’t know its context, but all it needs is <code>op</code> to tell it what the numeric-only operator was and it can produce a nice error message. It leaves an error in the AST using <code>record_error</code>, its caller can then simply <code>return</code> if anything goes wrong.</p>
 <p>It’s not hard to guess how <code>sem_reject_real</code> works:</p>
 <div class="sourceCode" id="cb50"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb50-1"><a href="#cb50-1" aria-hidden="true" tabindex="-1"></a><span class="co">// Some math operators like &lt;&lt; &gt;&gt; &amp; | % only make sense on integers</span></span>
 <span id="cb50-2"><a href="#cb50-2" aria-hidden="true" tabindex="-1"></a><span class="co">// This function does the extra checking to ensure they do not get real values</span></span>
@@ -1241,13 +1262,16 @@ AST(or)</code></pre>
 <span id="cb50-11"><a href="#cb50-11" aria-hidden="true" tabindex="-1"></a>  <span class="op">}</span></span>
 <span id="cb50-12"><a href="#cb50-12" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span></code></pre></div>
 <ul>
-<li>if the AST node isn’t already an error, and it is of type real, report an error</li>
+<li>if the AST node isn’t already an error, and the node is of type “real”, report an error</li>
 <li>it assumes the type is already known to be numeric</li>
-<li>the pre-check for errors is to avoid double reporting if something has already gone wrong, the core type will be <code>SEM_TYPE_ERROR</code></li>
+<li>the pre-check for errors is to avoid double reporting; if something has already gone wrong, the core type will be <code>SEM_TYPE_ERROR</code>
+<ul>
+<li>no new error recording is needed in that case, obviously an error was already recorded</li>
+</ul></li>
 </ul>
 <h3 id="binary-operators">Binary Operators</h3>
 <h4 id="binary-prep">Binary Prep</h4>
-<p>The code pretty much speaks for itself, we’ll walk through it</p>
+<p>With the knowledge we have so far, this code pretty much speaks for itself, but we’ll walk through it.</p>
 <div class="sourceCode" id="cb51"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb51-1"><a href="#cb51-1" aria-hidden="true" tabindex="-1"></a><span class="co">// All the binary ops do the same preparation, they evaluate the left and the</span></span>
 <span id="cb51-2"><a href="#cb51-2" aria-hidden="true" tabindex="-1"></a><span class="co">// right expression, then they check those for errors.  Then they need</span></span>
 <span id="cb51-3"><a href="#cb51-3" aria-hidden="true" tabindex="-1"></a><span class="co">// the types of those expressions and the combined_flags of the result.  This</span></span>
@@ -1278,12 +1302,12 @@ AST(or)</code></pre>
 <span id="cb51-28"><a href="#cb51-28" aria-hidden="true" tabindex="-1"></a>  <span class="cf">return</span> true<span class="op">;</span></span>
 <span id="cb51-29"><a href="#cb51-29" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span></code></pre></div>
 <ul>
-<li><code>sem_expr</code> is used to recursively walk the left and right nodes</li>
-<li><code>is_error</code> checks if either had errors, if so, simply propogate the error</li>
+<li><code>sem_expr</code> : used to recursively walk the left and right nodes</li>
+<li><code>is_error</code> : checks if either side had errors, if so, simply propogate the error</li>
 <li>extract the left and right core types</li>
 <li>combine nullability and sensitivity flags</li>
 </ul>
-<p>These are the standard prep steps, the caller now has the core types of left and right plus combined flags on a silver platter.</p>
+<p>And that’s it! These are the standard prep steps for all binary operators. With this done, the caller has the core types of the left and right operands plus combined flags on a silver platter and one check is needed to detect if anything went wrong.</p>
 <h4 id="example-is-or-is-not">Example: Is or Is Not</h4>
 <p>This analyzer is the simplest of all the binaries</p>
 <div class="sourceCode" id="cb52"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb52-1"><a href="#cb52-1" aria-hidden="true" tabindex="-1"></a><span class="co">// IS and IS NOT are special in that they return a not null boolean.</span></span>
@@ -1302,8 +1326,8 @@ AST(or)</code></pre>
 <span id="cb52-14"><a href="#cb52-14" aria-hidden="true" tabindex="-1"></a>  ast<span class="op">-&gt;</span>sem <span class="op">=</span> new_sem<span class="op">(</span>SEM_TYPE_BOOL <span class="op">|</span> SEM_TYPE_NOTNULL <span class="op">|</span> sensitive_flag<span class="op">(</span>combined_flags<span class="op">));</span></span>
 <span id="cb52-15"><a href="#cb52-15" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span></code></pre></div>
 <ul>
-<li><code>sem_binary_prep</code> checks for errors in the left or right</li>
-<li><code>sem_verify_compat</code> ensures that left and right operands are type compatible (discussed later)</li>
+<li><code>sem_binary_prep</code> : checks for errors in the left or right</li>
+<li><code>sem_verify_compat</code> : ensures that left and right operands are type compatible (discussed later)</li>
 <li>the result is always of type <code>bool not null</code></li>
 </ul>
 <p>If either step goes wrong the error will naturally propogate.</p>
@@ -1340,21 +1364,22 @@ AST(or)</code></pre>
 <span id="cb53-29"><a href="#cb53-29" aria-hidden="true" tabindex="-1"></a>  ast<span class="op">-&gt;</span>sem <span class="op">=</span> new_sem<span class="op">(</span>core_type <span class="op">|</span> combined_flags<span class="op">);</span></span>
 <span id="cb53-30"><a href="#cb53-30" aria-hidden="true" tabindex="-1"></a>  ast<span class="op">-&gt;</span>sem<span class="op">-&gt;</span>kind <span class="op">=</span> kind<span class="op">;</span></span>
 <span id="cb53-31"><a href="#cb53-31" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span></code></pre></div>
+<p>Let’s have a look at those steps:</p>
 <ul>
-<li><code>sem_binary_prep</code> checks for errors on the left or right</li>
-<li><code>error_any_object</code> reports an error if the left or right is of type object</li>
-<li><code>error_any_blob_types</code> reports an error if the left or right is of type blob</li>
-<li><code>error_any_text_types</code> reports an error if the left or right is of type text</li>
-<li><code>sem_combine_type</code> computes the combined type, the smallest numeric type that holds both left and right
+<li><code>sem_binary_prep</code> : checks for errors on the left or right</li>
+<li><code>error_any_object</code> : reports an error if the left or right is of type object</li>
+<li><code>error_any_blob_types</code> : reports an error if the left or right is of type blob</li>
+<li><code>error_any_text_types</code> : reports an error if the left or right is of type text</li>
+<li><code>sem_combine_type</code> : computes the combined type, the smallest numeric type that holds both left and right
 <ul>
 <li>note the operands are now known to be numeric</li>
-<li>the three type error checkers give nice right errors about the left or right operand</li>
+<li>the three type error checkers give nice tight errors about the left or right operand</li>
 </ul></li>
-<li><code>sem_combine_kinds</code> tries to create a single type <code>kind</code> for both operands
+<li><code>sem_combine_kinds</code> : tries to create a single type <code>kind</code> for both operands
 <ul>
 <li>if their <code>kind</code> is incompatible, records an error on the right</li>
 </ul></li>
-<li><code>new_sem</code> creates a <code>sem_node</code> with the combined type, flags, and then the <code>kind</code> is set.</li>
+<li><code>new_sem</code> : creates a <code>sem_node</code> with the combined type, flags, and then the <code>kind</code> is set.</li>
 </ul>
 <p>At this point it might help to look a few more of the base validators, they are very unremarkable.</p>
 <h4 id="example-validator-error_any_object">Example Validator: error_any_object</h4>
@@ -1375,9 +1400,11 @@ AST(or)</code></pre>
 <span id="cb54-15"><a href="#cb54-15" aria-hidden="true" tabindex="-1"></a>  <span class="cf">return</span> false<span class="op">;</span></span>
 <span id="cb54-16"><a href="#cb54-16" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span></code></pre></div>
 <ul>
-<li><code>is_object</code> checks a <code>sem_type</code> against <code>SEM_TYPE_OBJECT</code></li>
-<li>if left or right is an object an appropraite error is generated</li>
-<li>there is no strong convention about returning <code>true</code> if ok or <code>true</code> if error, it’s pretty ad hoc
+<li><code>is_object</code> : checks a <code>sem_type</code> against <code>SEM_TYPE_OBJECT</code>
+<ul>
+<li>if the left or right child is an object an appropraite error is generated</li>
+</ul></li>
+<li>there is no strong convention about returning <code>true</code> if ok, or <code>true</code> if error, it’s pretty ad hoc
 <ul>
 <li>this doesn’t seem to cause a lot of problems</li>
 </ul></li>
@@ -1408,27 +1435,27 @@ AST(or)</code></pre>
 <span id="cb55-23"><a href="#cb55-23" aria-hidden="true" tabindex="-1"></a>  <span class="cf">return</span> sem_combine_kinds_general<span class="op">(</span>ast<span class="op">,</span> kleft<span class="op">,</span> kright<span class="op">);</span></span>
 <span id="cb55-24"><a href="#cb55-24" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span></code></pre></div>
 <ul>
-<li><code>sem_combine_kinds</code> uses the worker <code>sem_combine_kinds_general</code> after extracting the <code>kind</code> from the left node
+<li><code>sem_combine_kinds</code> : uses the worker <code>sem_combine_kinds_general</code> after extracting the <code>kind</code> from the left node
 <ul>
 <li>usually you already have one <code>kind</code> and you want to know if another <code>kind</code> is compatible hence this helper</li>
 </ul></li>
-<li><code>sem_combine_kinds_general</code> applies the general rules
+<li><code>sem_combine_kinds_general</code> : applies the general rules for “kind” strings:
 <ul>
 <li>NULL + NULL =&gt; NULL</li>
 <li>NULL + x =&gt; x</li>
 <li>x + NULL =&gt; x</li>
 <li>x + x =&gt; x</li>
-<li>x + y =&gt; error if x != y</li>
+<li>x + y =&gt; error (if x != y)</li>
 </ul></li>
 <li>this is one of the rare functions that creates a dynamic error message</li>
 </ul>
 <h4 id="example-validator-is_numeric_compat">Example Validator : is_numeric_compat</h4>
-<p>This helper is frequently called several times in the course of other semantic checks. This one produces no errors, that’s up to the caller. Often there is a numeric path and a non-numeric path so this helper can’t create the errors.</p>
+<p>This helper is frequently called several times in the course of other semantic checks. This one produces no errors, that’s up to the caller. Often there is a numeric path and a non-numeric path so this helper can’t create the errors as it doesn’t yet know if anything bad has happened. Most of the <code>is_something</code> functions are the same way.</p>
 <div class="sourceCode" id="cb56"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb56-1"><a href="#cb56-1" aria-hidden="true" tabindex="-1"></a>cql_noexport bool_t is_numeric_compat<span class="op">(</span>sem_t sem_type<span class="op">)</span> <span class="op">{</span></span>
 <span id="cb56-2"><a href="#cb56-2" aria-hidden="true" tabindex="-1"></a>  sem_type <span class="op">=</span> core_type_of<span class="op">(</span>sem_type<span class="op">);</span></span>
 <span id="cb56-3"><a href="#cb56-3" aria-hidden="true" tabindex="-1"></a>  <span class="cf">return</span> sem_type <span class="op">&gt;=</span> SEM_TYPE_NULL <span class="op">&amp;&amp;</span> sem_type <span class="op">&lt;=</span> SEM_TYPE_REAL<span class="op">;</span></span>
 <span id="cb56-4"><a href="#cb56-4" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span></code></pre></div>
-<p>It operates by checking the core type for the numeric range. Note that <code>NULL</code> is compatible with numerics because expressions like <code>NULL + 2</code> have meaning in SQL.</p>
+<p><code>is_numeric_compat</code> operates by checking the core type for the numeric range. Note that <code>NULL</code> is compatible with numerics because expressions like <code>NULL + 2</code> have meaning in SQL. The type of that expression is nullable integer and the result is <code>NULL</code>.</p>
 <h4 id="example-validator-sem_combine_types">Example Validator : sem_combine_types</h4>
 <div class="sourceCode" id="cb57"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb57-1"><a href="#cb57-1" aria-hidden="true" tabindex="-1"></a><span class="co">// The second workhorse of semantic analysis, given two types that</span></span>
 <span id="cb57-2"><a href="#cb57-2" aria-hidden="true" tabindex="-1"></a><span class="co">// are previously known to be compatible, it returns the smallest type</span></span>
@@ -1436,9 +1463,9 @@ AST(or)</code></pre>
 <span id="cb57-4"><a href="#cb57-4" aria-hidden="true" tabindex="-1"></a><span class="co">// Note: in the few cases where that isn&#39;t true the normal algorithm for</span></span>
 <span id="cb57-5"><a href="#cb57-5" aria-hidden="true" tabindex="-1"></a><span class="co">// nullablity result must be overrided (see coalesce for instance).</span></span>
 <span id="cb57-6"><a href="#cb57-6" aria-hidden="true" tabindex="-1"></a><span class="dt">static</span> sem_t sem_combine_types<span class="op">(</span>sem_t sem_type_1<span class="op">,</span> sem_t sem_type_2<span class="op">)</span> <span class="op">{</span></span>
-<span id="cb57-7"><a href="#cb57-7" aria-hidden="true" tabindex="-1"></a>  <span class="op">...</span></span>
+<span id="cb57-7"><a href="#cb57-7" aria-hidden="true" tabindex="-1"></a>  <span class="op">...</span> too much code <span class="op">...</span> summary below</span>
 <span id="cb57-8"><a href="#cb57-8" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span></code></pre></div>
-<p>This beast is rather lengthy but unremarkable. It follows these rules: * text is only compatible with text * object is only compatible with object * blob is only compatible with blob * numerics are only compatible with any other numerics * NULL promotes the other operand, whatever it is * bool promotes to integer * integer promotes to long integer * long integer promotes to real * the combined type is the smallest numeric type according to the promotion rules</p>
+<p>This beast is rather lengthy but unremarkable. It follows these rules: * text is only compatible with text * object is only compatible with object * blob is only compatible with blob * numerics are only compatible with other numerics and NULL * NULL promotes the other operand, whatever it is (might still be NULL) * bool promotes to integer if needed * integer promotes to long integer if needed * long integer promotes to real if needed * the combined type is the smallest numeric type that holds left and right according to the above</p>
 <p>Some examples might be helpful:</p>
 <ul>
 <li>1 + 2L -&gt; long</li>
@@ -1449,12 +1476,12 @@ AST(or)</code></pre>
 </ul>
 <p>Note that <code>sem_combine_types</code> assumes the types have already been checked for compatiblitiy and will use <code>Contract</code> to enforce this. You should be using other helpers like <code>is_numeric_compat</code> and friends to ensure the types agree before computing the combined type. A list of values that must be compatible with each other (e.g. in <code>needle IN (haystack)</code>) can be checked using <code>sem_verify_compat</code> repeatedly.</p>
 <h4 id="example-validator-sem_verify_assignment">Example Validator : sem_verify_assignment</h4>
-<p>The <code>sem_verify_assignment</code> function is use any time there is something like a logical <code>assignment</code> going on. There are two important cases:</p>
+<p>The <code>sem_verify_assignment</code> function is used any time there is something like a logical <code>assignment</code> going on. There are two important cases:</p>
 <ul>
 <li><code>SET x := y</code> : an actual assignment</li>
 <li><code>call foo(x)</code> : the expression <code>x</code> must be “assignable” to the formal variable for the argument of <code>foo</code></li>
 </ul>
-<p>This is a lot like normal binary operator compatibility with one extra rule. The expression must not be a bigger type than the target. i.e. you cannot assign a <code>long</code> to an <code>integer</code>.</p>
+<p>This is a lot like normal binary operator compatibility with one extra rule: the source expression must not be a bigger type than the target. e.g. you cannot assign a <code>long</code> to an <code>integer</code>, nor pass a long expression to a function that has an integer parameter.</p>
 <div class="sourceCode" id="cb58"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb58-1"><a href="#cb58-1" aria-hidden="true" tabindex="-1"></a><span class="co">// This verifies that the types are compatible and that it&#39;s ok to assign</span></span>
 <span id="cb58-2"><a href="#cb58-2" aria-hidden="true" tabindex="-1"></a><span class="co">// the expression to the variable.  In practice that means:</span></span>
 <span id="cb58-3"><a href="#cb58-3" aria-hidden="true" tabindex="-1"></a><span class="co">// * the variable type core type and kind must be compatible with the expression core type and kind</span></span>
@@ -1484,8 +1511,8 @@ AST(or)</code></pre>
 <span id="cb58-27"><a href="#cb58-27" aria-hidden="true" tabindex="-1"></a>  <span class="cf">return</span> true<span class="op">;</span></span>
 <span id="cb58-28"><a href="#cb58-28" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span></code></pre></div>
 <ul>
-<li><code>sem_verify_compat</code> checks for standard type compatibility between the left and the right</li>
-<li><code>sem_verify_safeassign</code> checks that if the types are different the right operand is the smaller</li>
+<li><code>sem_verify_compat</code> : checks for standard type compatibility between the left and the right</li>
+<li><code>sem_verify_safeassign</code> : checks that if the types are different the right operand is the smaller</li>
 <li>nullability checks ensure you aren’t trying to assign a nullable value to a not null variable</li>
 <li>sensitivity checks ensure you aren’t trying to assign a sensitive value to a not sensitive variable</li>
 </ul>
@@ -1525,15 +1552,15 @@ AST(or)</code></pre>
 <span id="cb59-32"><a href="#cb59-32" aria-hidden="true" tabindex="-1"></a>  record_ok<span class="op">(</span>ast<span class="op">);</span></span>
 <span id="cb59-33"><a href="#cb59-33" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span></code></pre></div>
 <ul>
-<li>first we pull out the tree parts we need using <code>EXTRACT</code> macros</li>
-<li>the loop expression verified to be numeric</li>
-<li>then the statement list is recursively validated</li>
+<li><code>EXTRACT*</code> : pulls out the tree parts we need</li>
+<li><code>sem_numeric_expr</code> : verifies the loop expression is numeric</li>
+<li><code>sem_stmt_list</code> : recursively validates the body of the loop</li>
 </ul>
-<p>Note: the while expression is one of the loop constructs which means <code>LEAVE</code> and <code>CONTINUE</code> are legal inside it, the <code>loop_depth</code> global tracks the fact that we are in a loop so that <code>LEAVE</code> and <code>CONTINUE</code> can report errors if we are not.</p>
-<p>It’s not hard to imagine that <code>sem_stmt_list</code> will basically walk the AST, pulling out statements and dispatching them using the <code>STMT_INIT</code> tables previously discussed. Hence you could land right back in <code>sem_while_stmt</code> for a nested <code>WHILE</code>. It’s turtles all the way down.</p>
+<p>Note: the while expression is one of the loop constructs which means <code>LEAVE</code> and <code>CONTINUE</code> are legal inside it. The <code>loop_depth</code> global tracks the fact that we are in a loop so that analysis for <code>LEAVE</code> and <code>CONTINUE</code> can report errors if we are not.</p>
+<p>It’s not hard to imagine that <code>sem_stmt_list</code> will basically walk the AST, pulling out statements and dispatching them using the <code>STMT_INIT</code> tables previously discussed. You might land right back in <code>sem_while_stmt</code> for a nested <code>WHILE</code> – it’s turtles all the way down.</p>
 <p>If <code>SEM_EXPR_CONTEXT_NONE</code> is a mystery, don’t worry it’s covered in the next section.</p>
 <h3 id="expression-contexts">Expression Contexts</h3>
-<p>It turns out that in the SQL language some expression types are only valid in some parts of a SQL statement (e.g. aggregate functions can’t appear in a <code>LIMIT</code> clause) and so there is always a context for any numeric expression. When a new root expression is being evaluated, it sets the xpression context according to the caller.</p>
+<p>It turns out that in the SQL language some expression types are only valid in some parts of a SQL statement (e.g. aggregate functions can’t appear in a <code>LIMIT</code> clause) and so there is always a context for any numeric expression. When a new root expression is being evaluated, it sets the expression context per the caller’s specification.</p>
 <p>The expression contexts are as follows:</p>
 <div class="sourceCode" id="cb60"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb60-1"><a href="#cb60-1" aria-hidden="true" tabindex="-1"></a><span class="pp">#define SEM_EXPR_CONTEXT_NONE           0x0001</span></span>
 <span id="cb60-2"><a href="#cb60-2" aria-hidden="true" tabindex="-1"></a><span class="pp">#define SEM_EXPR_CONTEXT_SELECT_LIST    0x0002</span></span>
@@ -1548,20 +1575,20 @@ AST(or)</code></pre>
 <span id="cb60-11"><a href="#cb60-11" aria-hidden="true" tabindex="-1"></a><span class="pp">#define SEM_EXPR_CONTEXT_WINDOW         0x0400</span></span>
 <span id="cb60-12"><a href="#cb60-12" aria-hidden="true" tabindex="-1"></a><span class="pp">#define SEM_EXPR_CONTEXT_WINDOW_FILTER  0x0800</span></span>
 <span id="cb60-13"><a href="#cb60-13" aria-hidden="true" tabindex="-1"></a><span class="pp">#define SEM_EXPR_CONTEXT_CONSTRAINT     0x1000</span></span></code></pre></div>
-<p>The idea here is simple, you set the context bit that correponds to the current context such as <code>SEM_EXPR_CONTEXT_WHERE</code> if the expression is in the <code>WHERE</code> clause. The validators check this context, in particular anything that is only available in some contexts has a bit-mask of the context bits where it can be used. It checks the possibilities against the current context with one bitwise “and” operation. A zero result indicates that the operation is not valid in the current context.</p>
-<p>This bitwise “and” is performed by one of these two helper macros which makes the usage a little clearer</p>
+<p>The idea here is simple, when calling a root expression, the analyzer provides the context value that has the bit that correponds to the current context. For instance, the expression being validated in is the <code>WHERE</code> clause, the code will provide <code>SEM_EXPR_CONTEXT_WHERE</code>. The inner validators check this context, in particular anything that is only available in some contexts has a bit-mask of that is the union of the context bits where it can be used. The validator can check those possibilities against the current context with one bitwise “and” operation. A zero result indicates that the operation is not valid in the current context.</p>
+<p>This bitwise “and” is performed by one of these two helper macros which makes the usage a little clearer:</p>
 <div class="sourceCode" id="cb61"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb61-1"><a href="#cb61-1" aria-hidden="true" tabindex="-1"></a><span class="pp">#define CURRENT_EXPR_CONTEXT_IS(x)  (!!(current_expr_context &amp; (x)))</span></span>
 <span id="cb61-2"><a href="#cb61-2" aria-hidden="true" tabindex="-1"></a><span class="pp">#define CURRENT_EXPR_CONTEXT_IS_NOT(x)  (!(current_expr_context &amp; (x)))</span></span></code></pre></div>
 <h4 id="expression-context-example-concat">Expression Context Example : Concat</h4>
-<p>The concatenation operator <code>||</code> is challenging to successfully emulate because it does many different kinds of numeric conversions automatically. Rather than perenially getting this wrong, we simply do not support this operator in a context where SQLite isn’t going to be doing the concatenation. So typically you use “printf” instead to get your formatting done outside of a SQL state. The check for this is very simple and it happens of course in <code>sem_concat</code>.</p>
+<p>The concatenation operator <code>||</code> is challenging to successfully emulate because it does many different kinds of numeric to string conversions automatically. Rather than perenially getting this wrong, we simply do not support this operator in a context where SQLite isn’t going to be doing the concatenation. So typically users use “printf” instead to get formatting done outside of a SQL context. The check for invalid use of <code>||</code> is very simple and it happens of course in <code>sem_concat</code>.</p>
 <div class="sourceCode" id="cb62"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb62-1"><a href="#cb62-1" aria-hidden="true" tabindex="-1"></a>  <span class="cf">if</span> <span class="op">(</span>CURRENT_EXPR_CONTEXT_IS<span class="op">(</span>SEM_EXPR_CONTEXT_NONE<span class="op">))</span> <span class="op">{</span></span>
 <span id="cb62-2"><a href="#cb62-2" aria-hidden="true" tabindex="-1"></a>    report_error<span class="op">(</span>ast<span class="op">,</span> <span class="st">&quot;CQL0241: CONCAT may only appear in the context of a SQL statement&quot;</span><span class="op">,</span> NULL<span class="op">);</span></span>
 <span id="cb62-3"><a href="#cb62-3" aria-hidden="true" tabindex="-1"></a>    record_error<span class="op">(</span>ast<span class="op">);</span></span>
 <span id="cb62-4"><a href="#cb62-4" aria-hidden="true" tabindex="-1"></a>    <span class="cf">return</span><span class="op">;</span></span>
 <span id="cb62-5"><a href="#cb62-5" aria-hidden="true" tabindex="-1"></a>  <span class="op">}</span></span></code></pre></div>
 <h4 id="expression-context-example-in">Expression Context Example : IN</h4>
-<p>A slightly more complex example happens processing the <code>IN</code> operator. This operator has two forms, the form with an expression list, which can be used anywhere, and the form with a select statement. The latter form can only appear in some sections of SQL and not at all in loose expressions. For instance, that form may not appear in the <code>LIMIT</code> or <code>OFFSET</code> sections of a SQLite statement.</p>
-<p>We use this construct to get all the bits we like.</p>
+<p>A slightly more complex example happens processing the <code>IN</code> operator. This operator has two forms, the form with an expression list, which can be used anywhere, and the form with a <code>SELECT</code> statement. The latter form can only appear in some sections of SQL, and not at all in loose expressions. For instance, that form may not appear in the <code>LIMIT</code> or <code>OFFSET</code> sections of a SQLite statement.</p>
+<p>We use this construct to do the validation:</p>
 <div class="sourceCode" id="cb63"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb63-1"><a href="#cb63-1" aria-hidden="true" tabindex="-1"></a>    <span class="dt">uint32_t</span> valid <span class="op">=</span> SEM_EXPR_CONTEXT_SELECT_LIST</span>
 <span id="cb63-2"><a href="#cb63-2" aria-hidden="true" tabindex="-1"></a>                    <span class="op">|</span>SEM_EXPR_CONTEXT_WHERE</span>
 <span id="cb63-3"><a href="#cb63-3" aria-hidden="true" tabindex="-1"></a>                    <span class="op">|</span>SEM_EXPR_CONTEXT_ON</span>
@@ -1574,11 +1601,11 @@ AST(or)</code></pre>
 <span id="cb63-10"><a href="#cb63-10" aria-hidden="true" tabindex="-1"></a>      record_error<span class="op">(</span>ast<span class="op">);</span></span>
 <span id="cb63-11"><a href="#cb63-11" aria-hidden="true" tabindex="-1"></a>      <span class="cf">return</span><span class="op">;</span></span>
 <span id="cb63-12"><a href="#cb63-12" aria-hidden="true" tabindex="-1"></a>    <span class="op">}</span></span></code></pre></div>
-<p>If the reader is interested in a simple learning exercise, run down the purpose of <code>SEM_EXPR_CONTEXT_TABLE_FUNC</code>, it’s simple but important and it only has one use case so it’s easy to find.</p>
+<p>If the reader is interested in a simple learning exercise, run down the purpose of <code>SEM_EXPR_CONTEXT_TABLE_FUNC</code> – it’s simple, but important, and it only has one use case so it’s easy to find.</p>
 <h3 id="name-resolution">Name Resolution</h3>
 <p>We’ve gotten pretty far without talking about the elephant in the room: name resolution.</p>
-<p>Like SQL, many statements in CQL have names in positions where the type of the name is completely unambiguous. For instance nobody could be confused what sort of symbol <code>Foo</code> is in <code>DROP INDEX Foo;</code></p>
-<p>These are the easiest name resolutions, and there are a lot in this form. Let’s do an example</p>
+<p>Like SQL, many statements in CQL have names in positions where the type of the name is completely unambiguous. For instance nobody could be confused what sort of symbol <code>Foo</code> is in <code>DROP INDEX Foo</code>.</p>
+<p>This type, with a clear name category, are the easiest name resolutions, and there are a lot in this form. Let’s do an example.</p>
 <h4 id="example-index-name-resolution">Example: Index Name Resolution</h4>
 <div class="sourceCode" id="cb64"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb64-1"><a href="#cb64-1" aria-hidden="true" tabindex="-1"></a><span class="co">// This is the basic checking for the drop index statement</span></span>
 <span id="cb64-2"><a href="#cb64-2" aria-hidden="true" tabindex="-1"></a><span class="co">// * the index must exist (have been declared) in some version</span></span>
@@ -1596,7 +1623,7 @@ AST(or)</code></pre>
 <span id="cb64-14"><a href="#cb64-14" aria-hidden="true" tabindex="-1"></a></span>
 <span id="cb64-15"><a href="#cb64-15" aria-hidden="true" tabindex="-1"></a>  record_ok<span class="op">(</span>ast<span class="op">);</span></span>
 <span id="cb64-16"><a href="#cb64-16" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span></code></pre></div>
-<p>Well, this is interesting. But what’s going on with <code>find_usable_index</code> what is usable? Why aren’t we just looking up the index name in some name table and that’s it. Let’s have a look at the details:</p>
+<p>Well, this is interesting. But what’s going on with <code>find_usable_index</code>? What is usable? Why aren’t we just looking up the index name in some name table? Let’s have a look at the details of <code>find_usable_index</code>.</p>
 <div class="sourceCode" id="cb65"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb65-1"><a href="#cb65-1" aria-hidden="true" tabindex="-1"></a><span class="co">// returns the node only if it exists and is not restricted by the schema region.</span></span>
 <span id="cb65-2"><a href="#cb65-2" aria-hidden="true" tabindex="-1"></a><span class="dt">static</span> ast_node <span class="op">*</span>find_usable_index<span class="op">(</span>CSTR name<span class="op">,</span> ast_node <span class="op">*</span>err_target<span class="op">,</span> CSTR msg<span class="op">)</span> <span class="op">{</span></span>
 <span id="cb65-3"><a href="#cb65-3" aria-hidden="true" tabindex="-1"></a>  ast_node <span class="op">*</span>index_ast <span class="op">=</span> find_index<span class="op">(</span>name<span class="op">);</span></span>
@@ -1611,13 +1638,15 @@ AST(or)</code></pre>
 <span id="cb65-12"><a href="#cb65-12" aria-hidden="true" tabindex="-1"></a></span>
 <span id="cb65-13"><a href="#cb65-13" aria-hidden="true" tabindex="-1"></a>  <span class="cf">return</span> index_ast<span class="op">;</span></span>
 <span id="cb65-14"><a href="#cb65-14" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span></code></pre></div>
-<p>We haven’t discussed schema regions yet but what you need to know about them for now is this: any piece of schema can be in a region and these can be nested. A region may depend on other regions. If this is done then the region may only use schema parts that are in its dependencies (transitively). The point of this is that you might have a rather large schema and you probably don’t want any peice of code to use any piece of schema. You can use regions to ensure that the code for feature “X” doesn’t try to use schema designed exclusively for feature “Y”.</p>
-<p>So now <code>usable</code> simply means, we can find the name in the symbol table for indices that’s <code>find_index</code> and it is accessible by the current region.</p>
-<p>If we had used an example requiring a table or a column the same considerations would apply however additionally tables can be deprecated with <code>@delete</code> so we might need additional checks to make sure we’re talking about a table, not a table’s tombstone.</p>
-<p>In short, these cases just require looking up the entity and verifying that it’s accessible in the current context.</p>
+<p>We haven’t discussed schema regions yet but what you need to know about them for now is this: * any object can be in a region. * a region may depend on other regions</p>
+<p>If an object is in a region, then it may only use schema parts that are in the same region, or the region’s dependencies (transitively).</p>
+<p>The point of this is that you might have a rather large schema and you probably don’t want any peice of code to use any piece of schema. You can use regions to ensure that the code for feature “X” doesn’t try to use schema designed exclusively for feature “Y”. That “X” code probably has no business even knowing of the existence of “Y” schema.</p>
+<p>So now <code>usable</code> simply means this: * <code>find_index</code> can find the name in the symbol table for indices * the found index is accessible in the current region</p>
+<p>If we had used an example that was looking up a table name, the same region considerations would apply, however, additionally tables can be deprecated with <code>@delete</code> so there would be additional checks to make sure we’re talking about a live table and not a table’s tombstone.</p>
+<p>In short, these simple cases just require looking up the entity and verifying that it’s accessible in the current context.</p>
 <h4 id="flexible-name-resolution">Flexible Name Resolution</h4>
-<p>The “hard case” for name resolution is where the name is occuring in an expression. Such a name might mean a lot of things. It could be a global variable, a local variable, an argument, a table column, a field in a cursor, and others. The general name resolution goes through several phases looking for the name. Each phase can either report an affirmative success or error (in which case the search stops), or it may simply report that the name was not found but the search should continue.</p>
-<p>We can demystify this a bit by looking at the two most common ways to get this done.</p>
+<p>The “hard case” for name resolution is where the name is occuring in an expression. Such a name can refer to all manner of things. It could be a global variable, a local variable, an argument, a table column, a field in a cursor, and others. The general name resolver goes through several phases looking for the name. Each phase can either report an affirmative success or error (in which case the search stops), or it may simply report that the name was not found but the search should continue.</p>
+<p>We can demystify this a bit by looking at the most common way to get name resolution done.</p>
 <div class="sourceCode" id="cb66"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb66-1"><a href="#cb66-1" aria-hidden="true" tabindex="-1"></a><span class="co">// Resolves a (potentially qualified) identifier, writing semantic information</span></span>
 <span id="cb66-2"><a href="#cb66-2" aria-hidden="true" tabindex="-1"></a><span class="co">// into `ast` if successful, or reporting and recording an error for `ast` if</span></span>
 <span id="cb66-3"><a href="#cb66-3" aria-hidden="true" tabindex="-1"></a><span class="co">// not.</span></span>
@@ -1629,8 +1658,8 @@ AST(or)</code></pre>
 <span id="cb66-9"><a href="#cb66-9" aria-hidden="true" tabindex="-1"></a>  sem_t <span class="op">*</span>type <span class="op">=</span> NULL<span class="op">;</span></span>
 <span id="cb66-10"><a href="#cb66-10" aria-hidden="true" tabindex="-1"></a>  sem_resolve_id_with_type<span class="op">(</span>ast<span class="op">,</span> name<span class="op">,</span> scope<span class="op">,</span> <span class="op">&amp;</span>type<span class="op">);</span></span>
 <span id="cb66-11"><a href="#cb66-11" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span></code></pre></div>
-<p>The name resolver works on either a vanilla name (e.g. <code>x</code>) or a scoped name (e.g. <code>T1.x</code>). The name and scope are provided. The <code>ast</code> parameter is used only as a place to report errors, there is no further cracking of the ast needed to resolve the name. As you can see <code>sem_resolve_id</code> just calls the more general function <code>sem_resolve_id_with_type</code> and is used in the most common case where you don’t need the sematic type info for the identifier.</p>
-<p>Let’s move on to the “real” resolver.</p>
+<p>The name resolver works on either a vanilla name (e.g. <code>x</code>) or a scoped name (e.g. <code>T1.x</code>). The name and scope are provided. The <code>ast</code> parameter is used only as a place to report errors, there is no further cracking of the AST needed to resolve the name. As you can see <code>sem_resolve_id</code> just calls the more general function <code>sem_resolve_id_with_type</code> and is used in the most common case where you don’t need to be able to mutate the sematic type info for the identifier. That’s the 99% case.</p>
+<p>So let’s move on to the “real” resolver.</p>
 <div class="sourceCode" id="cb67"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb67-1"><a href="#cb67-1" aria-hidden="true" tabindex="-1"></a><span class="co">// This function is responsible for resolving both unqualified identifiers (ids)</span></span>
 <span id="cb67-2"><a href="#cb67-2" aria-hidden="true" tabindex="-1"></a><span class="co">// and qualified identifiers (dots). It performs the following two roles:</span></span>
 <span id="cb67-3"><a href="#cb67-3" aria-hidden="true" tabindex="-1"></a><span class="co">//</span></span>
@@ -1690,7 +1719,7 @@ AST(or)</code></pre>
 <span id="cb67-57"><a href="#cb67-57" aria-hidden="true" tabindex="-1"></a>  report_resolve_error<span class="op">(</span>ast<span class="op">,</span> <span class="st">&quot;CQL0069: name not found&quot;</span><span class="op">,</span> name<span class="op">);</span></span>
 <span id="cb67-58"><a href="#cb67-58" aria-hidden="true" tabindex="-1"></a>  record_resolve_error<span class="op">(</span>ast<span class="op">);</span></span>
 <span id="cb67-59"><a href="#cb67-59" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span></code></pre></div>
-<p>A lot is well described in the comments, but already we can see the structure. There are “mini-resolvers” which are attempted in order</p>
+<p>This function is well described in its own comments. We can easily see the “mini-resolvers” which attempt to find the name in order:</p>
 <ul>
 <li><code>sem_try_resolve_arguments</code> : an argument in the argument list</li>
 <li><code>sem_try_resolve_column</code> : a column name (possibly scoped)</li>
@@ -1712,19 +1741,19 @@ AST(or)</code></pre>
 <span id="cb68-8"><a href="#cb68-8" aria-hidden="true" tabindex="-1"></a><span class="op">}</span> sem_resolve<span class="op">;</span></span></code></pre></div>
 <p>Each of these mini-resolvers will have a series of rules, for example <code>sem_try_resolve_cursor_field</code> is going to have to do something like this:</p>
 <ul>
-<li>if there is no scope it can’t be a cursor field, return <code>CONTINUE</code></li>
+<li>if there is no scope, it can’t be a cursor field, return <code>CONTINUE</code></li>
 <li>if the scope is not the name of a cursor, return <code>CONTINUE</code></li>
 <li>if the name is a field in the cursor, return <code>STOP</code> with success</li>
 <li>else, report that the name is not a valid member of the cursor, and return <code>STOP</code> with an error</li>
 </ul>
-<p>All the mini-resolvers are similarly structured:</p>
+<p>All the mini-resolvers are similarly structured, generically:</p>
 <ul>
 <li>if it’s not my case, return <code>CONTINUE</code></li>
-<li>if it is my case return <code>STOP</code> with an error as appropriate</li>
+<li>if it is my case return <code>STOP</code> (maybe with an error)</li>
 </ul>
-<p>Some of the resolvers have quite a few steps but any one resolver is only about a screenful of code and it does one job.</p>
+<p>Some of the mini-resolvers have quite a few steps but any one mini-resolver is only about a screenful of code and it does one job.</p>
 <h3 id="structure-types-and-the-notion-of-shapes">Structure types and the notion of Shapes</h3>
-<p>Earlier we discussed <code>SEM_TYPE_STRUCT</code> briefly and recall the basic notion of the <code>structure</code> type</p>
+<p>Earlier we discussed <code>SEM_TYPE_STRUCT</code> briefly. Recall the basic notion of the <code>structure</code> type:</p>
 <div class="sourceCode" id="cb69"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb69-1"><a href="#cb69-1" aria-hidden="true" tabindex="-1"></a><span class="co">// for tables and views and the result of a select</span></span>
 <span id="cb69-2"><a href="#cb69-2" aria-hidden="true" tabindex="-1"></a></span>
 <span id="cb69-3"><a href="#cb69-3" aria-hidden="true" tabindex="-1"></a><span class="kw">typedef</span> <span class="kw">struct</span> sem_struct <span class="op">{</span></span>
@@ -1786,24 +1815,26 @@ AST(or)</code></pre>
 <span id="cb70-48"><a href="#cb70-48" aria-hidden="true" tabindex="-1"></a>  ast<span class="op">-&gt;</span>sem<span class="op">-&gt;</span>jptr <span class="op">=</span> sem_join_from_sem_struct<span class="op">(</span>sptr<span class="op">);</span></span>
 <span id="cb70-49"><a href="#cb70-49" aria-hidden="true" tabindex="-1"></a>  ast<span class="op">-&gt;</span>sem<span class="op">-&gt;</span>region <span class="op">=</span> current_region<span class="op">;</span></span></code></pre></div>
 <ul>
-<li><code>new_sem_struct</code> makes a struct to hold the result, we already have the count of columns and the table name</li>
-<li><code>symtab_new</code> is going to gives us a scratch symbol table so we can check for duplicate column names</li>
+<li><code>new_sem_struct</code> : makes a struct to hold the result, we already have the count of columns and the table name</li>
+<li><code>symtab_new</code> : is going to gives us a scratch symbol table so we can check for duplicate column names</li>
 <li>we walk all the items in the table and use <code>is_ast_col_def(def)</code> to find the column definitions</li>
-<li><code>Invariant(def-&gt;sem-&gt;name)</code> claims that we must have already computed the semantic info for the column and it has its name populated
+<li><code>Invariant(def-&gt;sem-&gt;name)</code> : claims that we must have already computed the semantic info for the column and it has its name populated
 <ul>
 <li>this was done earlier</li>
 </ul></li>
-<li><code>symtab_add(columns, def-&gt;sem-&gt;name, NULL)</code> adds a nil entry under the column name, if this fails we have a duplicate column
+<li><code>symtab_add(columns, def-&gt;sem-&gt;name, NULL)</code> : adds a nil entry under the column name, if this fails we have a duplicate column
 <ul>
 <li>in which case we report errors and stop</li>
 </ul></li>
-<li><code>is_deleted</code> tells us if the column was marked with <code>@delete</code> in which case it no longer counts as part of the table</li>
+<li><code>is_deleted</code> : tells us if the column was marked with <code>@delete</code> in which case it no longer counts as part of the table</li>
 <li>if all this is good we set the <code>names</code>, <code>kinds</code>, and <code>semtypes</code> from the column definition’s semnatic info</li>
-<li><code>symtab_delete</code> cleans up the temporary symbol table</li>
-<li>and finally we create a <code>sem_node</code> of type <code>SEM_TYPE_STRUCT</code> and fill it in</li>
-<li><code>sem_join_from_sem_struct</code> will be discussed shortly, but it creates a jptr with one table in it</li>
+<li><code>symtab_delete</code> : cleans up the temporary symbol table</li>
+<li><code>new_sem</code> : creates a <code>sem_node</code> of type <code>SEM_TYPE_STRUCT</code> which is filled in
+<ul>
+<li><code>sem_join_from_sem_struct</code> will be discussed shortly, but it creates a <code>jptr</code> with one table in it</li>
+</ul></li>
 </ul>
-<p>Structure types are often rooted in the shape of a table, but other things can create a structure type. For instance, the columns of a view, or any select statement are also described by a structure type and are therefore valid “shapes”. The return type of a procedure usually comes from a <code>SELECT</code> statement so the procedure too can be the source of a shape. The arguments of a procedure form a shape. The fields of a cursor form a shape. You can even have a named subset of the arguments of a procedure and use them like a shape. All of these things are described by structure types.</p>
+<p>Structure types often come from the shape of a table, but other things can create a structure type. For instance, the columns of a view, or any select statement, are also described by a structure type and are therefore valid “shapes”. The return type of a procedure usually comes from a <code>SELECT</code> statement so the procedure too can be the source of a shape. The arguments of a procedure form a shape. The fields of a cursor form a shape. You can even have a named subset of the arguments of a procedure and use them like a shape. All of these things are described by structure types.</p>
 <h4 id="shapes-and-the-like-construct">Shapes and the LIKE construct</h4>
 <p>There are many cases where you want to be able to capture or re-use something with a known shape and you don’t want to have to fully re-declare the thing. CQL uses the <code>LIKE</code> construct to do these sorts of things. This is more fully explained in <a href="https://cgsql.dev/cql-guide/ch05#reshaping-data-cursor-like-forms">Chapter 5</a> of the Guide, but for now let’s look at two different cases that are of interest.</p>
 <p>First, a cursor:</p>
@@ -1847,14 +1878,16 @@ AST(or)</code></pre>
 <span id="cb72-35"><a href="#cb72-35" aria-hidden="true" tabindex="-1"></a>  symtab_add<span class="op">(</span>current_variables<span class="op">,</span> new_cursor_name<span class="op">,</span> new_cursor_ast<span class="op">);</span></span>
 <span id="cb72-36"><a href="#cb72-36" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span></code></pre></div>
 <ul>
-<li><code>EXTRACT</code> the pieces we need from the AST</li>
-<li><code>sem_verify_legal_variable_name</code> makes sure the cursor name is unique and doesn’t hide a table name</li>
-<li><code>sem_find_likeable_ast</code> searches for something with a suitable name that has a shape</li>
-<li>re-use the semantic type of what we found in the name node</li>
-<li>make a new <code>sem_node</code> for the cursor variable</li>
-<li>use the <code>sptr</code> from the discovered shape for the type</li>
+<li><code>EXTRACT</code> : gets the pieces we need from the AST</li>
+<li><code>sem_verify_legal_variable_name</code> : makes sure the cursor name is unique and doesn’t hide a table name</li>
+<li><code>sem_find_likeable_ast</code> : searches for something with a suitable name that has a shape</li>
+<li>we populate the name node with the semantic type that we found</li>
+<li><code>new_sem</code> : makes a new <code>sem_node</code> for the cursor variable with <code>SEM_TYPE_STRUCT</code>
+<ul>
+<li>set the <code>sptr</code> field using the discovered shape</li>
+</ul></li>
 </ul>
-<p>Note: <code>name_ast-&gt;sem</code> isn’t actually interesting but it is helpful for debugging and if the AST is printed it shows the original unmodified semantic type on those nodes.</p>
+<p>Note: <code>name_ast-&gt;sem</code> isn’t actually used for anything but it is helpful for debugging. If the AST is printed it shows the original unmodified semantic type which can be helpful.</p>
 <p>Briefly <code>sem_find_likeable_ast</code> does these steps:</p>
 <ul>
 <li>if the right of the <code>LIKE</code> refers to procedure arguments (e.g. C LIKE Foo ARGUMENTS), get the args of the named procedure and use them as a shape</li>
@@ -1867,18 +1900,19 @@ AST(or)</code></pre>
 <li>if the right is the name of a procedure with a structure result, use that shape</li>
 <li>if it’s none of these, produce an error</li>
 </ul>
-<p>This is the primary source of shape reuse. Let’s look at how we might use that. Suppose we want to write a procedure that inserts a row into the table <code>Foo</code>. We could certainly list the columns of <code>Foo</code> as arguments like this:</p>
+<p>This is the primary source of shape reuse. Let’s look at how we might use that.</p>
+<p>Suppose we want to write a procedure that inserts a row into the table <code>Foo</code>, we could certainly list the columns of <code>Foo</code> as arguments like this:</p>
 <div class="sourceCode" id="cb73"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb73-1"><a href="#cb73-1" aria-hidden="true" tabindex="-1"></a><span class="kw">CREATE</span> PROC InsertIntoFoo(<span class="kw">id</span> <span class="dt">integer</span>, t text, r <span class="dt">real</span>, b <span class="dt">blob</span>)</span>
 <span id="cb73-2"><a href="#cb73-2" aria-hidden="true" tabindex="-1"></a><span class="cf">BEGIN</span></span>
 <span id="cb73-3"><a href="#cb73-3" aria-hidden="true" tabindex="-1"></a>  <span class="kw">INSERT</span> <span class="kw">INTO</span> Foo(<span class="kw">id</span>, t, r, b) <span class="kw">VALUES</span>(<span class="kw">id</span>, t, r, b);</span>
 <span id="cb73-4"><a href="#cb73-4" aria-hidden="true" tabindex="-1"></a><span class="cf">END</span>;</span></code></pre></div>
-<p>That is going to get a lot less exciting when there are lots of columns and it will be increasingly a maintenance headach.</p>
-<p>Compare with</p>
+<p>But that approach is going to get a lot less exciting when there are lots of columns and it will be increasingly a maintenance headache.</p>
+<p>Compare that with the following:</p>
 <div class="sourceCode" id="cb74"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb74-1"><a href="#cb74-1" aria-hidden="true" tabindex="-1"></a><span class="kw">CREATE</span> PROC InsertIntoFoo(<span class="kw">row</span> <span class="kw">LIKE</span> Foo)</span>
 <span id="cb74-2"><a href="#cb74-2" aria-hidden="true" tabindex="-1"></a><span class="cf">BEGIN</span></span>
 <span id="cb74-3"><a href="#cb74-3" aria-hidden="true" tabindex="-1"></a>  <span class="kw">INSERT</span> <span class="kw">INTO</span> Foo <span class="kw">FROM</span> <span class="kw">row</span>;</span>
 <span id="cb74-4"><a href="#cb74-4" aria-hidden="true" tabindex="-1"></a><span class="cf">END</span>;</span></code></pre></div>
-<p>These two things compile into the same code. The semantic analyzer expands the <code>(row LIKE Foo)</code> into <code>(row_id integer, row_t text, row_r real, row_b blob)</code> and then replaces <code>FROM row</code> with <code>(row_id, row_t, row_r, row_b)</code>. In both case it simply looked up the shape using <code>sem_find_likeable_ast</code> and then altered the AST to the canonical pattern. This kind of “shape sugar” is all over CQL and greatly increases maintainability while eliminating common errors. The most common operation is simply to expland a “shape” into a list of arguments or columns (maybe with or without type). SQLite doesn’t know any of this shape magic so by the time SQLite sees the code it has to look “normal” – the shapes are all resolved.</p>
+<p>Those two versions of <code>InsertIntoFoo</code> compile into the same code. The semantic analyzer expands the <code>(row LIKE Foo)</code> into <code>(row_id integer, row_t text, row_r real, row_b blob)</code> and then replaces <code>FROM row</code> with <code>(row_id, row_t, row_r, row_b)</code>. In both case it simply looked up the shape using <code>sem_find_likeable_ast</code> and then altered the AST to the canonical pattern. This kind of “shape sugar” is all over CQL and greatly increases maintainability while eliminating common errors. The most common operation is simply to expland a “shape” into a list of arguments or columns (maybe with or without type names). SQLite doesn’t know any of this shape magic so by the time SQLite sees the code it has to look “normal” – the shapes are all resolved.</p>
 <h3 id="join-types">Join Types</h3>
 <p>The last of the type building data structure is the join type. Recall that we have this shape:</p>
 <div class="sourceCode" id="cb75"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb75-1"><a href="#cb75-1" aria-hidden="true" tabindex="-1"></a><span class="co">// for the data type of (parts of) the FROM clause</span></span>
@@ -1889,9 +1923,10 @@ AST(or)</code></pre>
 <span id="cb75-6"><a href="#cb75-6" aria-hidden="true" tabindex="-1"></a>  CSTR <span class="op">*</span>names<span class="op">;</span>                    <span class="co">// names of the table/view</span></span>
 <span id="cb75-7"><a href="#cb75-7" aria-hidden="true" tabindex="-1"></a>  <span class="kw">struct</span> sem_struct <span class="op">**</span>tables<span class="op">;</span>     <span class="co">// struct type of each table/view</span></span>
 <span id="cb75-8"><a href="#cb75-8" aria-hidden="true" tabindex="-1"></a><span class="op">}</span> sem_join<span class="op">;</span></span></code></pre></div>
-<p>This is an array of named structure types, which is exactly what you get when you do something like this</p>
+<p>This is an array of named structure types, which is exactly what you get when you do something like this:</p>
 <div class="sourceCode" id="cb76"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb76-1"><a href="#cb76-1" aria-hidden="true" tabindex="-1"></a><span class="kw">select</span> <span class="op">*</span> <span class="kw">from</span> T1 <span class="kw">INNER</span> <span class="kw">JOIN</span> T2;</span></code></pre></div>
-<p>The result has all of the columns of T1 and all of the columns of T2. They can be referred to with scoped names like <code>T1.x</code> which means “find the <code>sptr</code> corresponding to the name <code>T1</code> then within that structure find the column named <code>x</code>”. In general, when we join, we take a <code>jptr</code> on the left and concatenate it with a <code>jptr</code> on the right. And for all this to work we have to start somewhere, usually single tables. As we saw when we make a table we use <code>sem_join_from_sem_struct</code> to make its initial <code>jptr</code>. Let’s have a look at that now.</p>
+<p>The result has all of the columns of <code>T1</code> and all of the columns of <code>T2</code>. They can be referred to with scoped names like <code>T1.x</code> which means “find the <code>sptr</code> corresponding to the name <code>T1</code> then within that structure find the column named <code>x</code>”. In general, when we join, we take a <code>jptr</code> on the left and concatenate it with a <code>jptr</code> on the right. For all this to work we have to start somewhere, usually single tables.</p>
+<p>As we saw when we make a table we use <code>sem_join_from_sem_struct</code> to make its initial <code>jptr</code>. Let’s have a look at that now:</p>
 <div class="sourceCode" id="cb77"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb77-1"><a href="#cb77-1" aria-hidden="true" tabindex="-1"></a><span class="co">// Create a base join type from a single struct.</span></span>
 <span id="cb77-2"><a href="#cb77-2" aria-hidden="true" tabindex="-1"></a><span class="dt">static</span> sem_join <span class="op">*</span>sem_join_from_sem_struct<span class="op">(</span>sem_struct <span class="op">*</span>sptr<span class="op">)</span> <span class="op">{</span></span>
 <span id="cb77-3"><a href="#cb77-3" aria-hidden="true" tabindex="-1"></a>  sem_join <span class="op">*</span>jptr <span class="op">=</span> new_sem_join<span class="op">(</span><span class="dv">1</span><span class="op">);</span></span>
@@ -1900,45 +1935,45 @@ AST(or)</code></pre>
 <span id="cb77-6"><a href="#cb77-6" aria-hidden="true" tabindex="-1"></a></span>
 <span id="cb77-7"><a href="#cb77-7" aria-hidden="true" tabindex="-1"></a>  <span class="cf">return</span> jptr<span class="op">;</span></span>
 <span id="cb77-8"><a href="#cb77-8" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span></code></pre></div>
-<p>It doesn’t get much simpler than the above:</p>
+<p>It doesn’t get much simpler than the above, here are the steps briefly:</p>
 <ul>
-<li><code>new_sem_join</code> gives us an empty <code>sem_join</code> with room for 1 table</li>
+<li><code>new_sem_join</code> : gives us an empty <code>sem_join</code> with room for 1 table</li>
 <li>we use the struct name for the name and the table’s <code>sptr</code> for the shape</li>
-<li><code>new_sem_struct_strip_table_flags</code> copies the table’s <code>sptr</code> keeping only the essential flags
+<li><code>new_sem_struct_strip_table_flags</code> : copies the table’s <code>sptr</code> keeping only the essential flags
 <ul>
 <li><code>SEM_TYPE_HIDDEN_COL</code></li>
 <li><code>SEM_FLAG_NOTNULL</code></li>
 <li><code>SEM_FLAG_SENSITIVE</code></li>
 </ul></li>
 </ul>
-<p>The other flags (e.g. <code>SEM_TYPE_PK</code>) have no value in doing type checking and were only needed to help validate the table itself. They would be harmless but they would also contaminate all of the debug output so they are stripped. As a result the type of columns as they appear in say <code>SELECT</code> statements is simpler than how they appear in a <code>CREATE TABLE</code> statement.</p>
-<p>When we need to create a new join type we simply (*) make a new join type that is the concatenation of the left and right parts of the join.</p>
+<p>The other flags (e.g. <code>SEM_TYPE_PK</code>) have no value in doing type checking and were only needed to help validate the table itself. Those extra flags would be harmless but they would also contaminate all of the debug output, so they are stripped. As a result the type of columns as they appear in say <code>SELECT</code> statements is simpler than how they appear in a <code>CREATE TABLE</code> statement.</p>
+<p>When we need to create a new join type we simply (*) make a new <code>sem_join</code> that is the concatenation of the left and right sides of the join operation.</p>
 <ul>
-<li>some join types change the nullability of columns like <code>LEFT JOIN</code> so we have to handle that too</li>
-<li>the names of the table in the new joinscope have to be unique so there is also error checking to do</li>
+<li>some join types change the nullability of columns like <code>LEFT JOIN</code>, so we have to handle that too</li>
+<li>the names of the tables in the new concatenated joinscope have to be unambiguous so there is also error checking to do</li>
 <li>but basically it’s just a concat…</li>
 </ul>
-<p>Importantly, we call the thing a “joinscope” because it creates a namespace. When we are evaluating names inside of the <code>FROM</code> clause or even later in say a <code>WHERE</code> clause, the joinscope that we have created so far controls the same of <code>table.column</code> combinations you can use in expressions. This changes again when there is a subquery, so the joinscopes can be pushed and popped as needed.</p>
+<p>Importantly, we call the thing a “joinscope” because it creates a namespace. When we are evaluating names inside of the <code>FROM</code> clause or even later in say a <code>WHERE</code> clause, the joinscope that we have created so far controls the <code>table.column</code> combinations you can use in expressions. This changes again when there is a subquery, so the joinscopes can be pushed and popped as needed.</p>
 <p>By way of example, you’ll see these two patterns in the code:</p>
 <div class="sourceCode" id="cb78"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb78-1"><a href="#cb78-1" aria-hidden="true" tabindex="-1"></a>  PUSH_JOIN<span class="op">(</span>from_scope<span class="op">,</span> select_from_etc<span class="op">-&gt;</span>sem<span class="op">-&gt;</span>jptr<span class="op">);</span></span>
 <span id="cb78-2"><a href="#cb78-2" aria-hidden="true" tabindex="-1"></a>  error <span class="op">=</span> sem_select_orderby<span class="op">(</span>select_orderby<span class="op">);</span></span>
 <span id="cb78-3"><a href="#cb78-3" aria-hidden="true" tabindex="-1"></a>  POP_JOIN<span class="op">();</span></span></code></pre></div>
 <ul>
-<li>use the <code>jptr</code> from the <code>FROM</code> clause to put things back in scope for the <code>ORDER BY</code> clause</li>
+<li><code>PUSH_JOIN</code> : use the <code>jptr</code> from the <code>FROM</code> clause to put things back in scope for the <code>ORDER BY</code> clause</li>
 </ul>
 <div class="sourceCode" id="cb79"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb79-1"><a href="#cb79-1" aria-hidden="true" tabindex="-1"></a>  PUSH_JOIN_BLOCK<span class="op">();</span></span>
 <span id="cb79-2"><a href="#cb79-2" aria-hidden="true" tabindex="-1"></a>  sem_numeric_expr<span class="op">(</span>ast<span class="op">-&gt;</span>left<span class="op">,</span> ast<span class="op">,</span> <span class="st">&quot;LIMIT&quot;</span><span class="op">,</span> SEM_EXPR_CONTEXT_LIMIT<span class="op">);</span></span>
 <span id="cb79-3"><a href="#cb79-3" aria-hidden="true" tabindex="-1"></a>  POP_JOIN<span class="op">();</span></span></code></pre></div>
 <ul>
-<li><code>PUSH_JOIN_BLOCK</code> causes the name search to stop, nothing deeper in the stack is searched</li>
-<li>in this case we do not allow <code>LIMIT</code> expressions to see any joinscopes, they may not use any columns.
+<li><code>PUSH_JOIN_BLOCK</code> : causes the name search to stop, nothing deeper in the stack is searched</li>
+<li>in this case we do not allow <code>LIMIT</code> expressions to see any joinscopes, they may not use any columns
 <ul>
 <li>even if the <code>LIMIT</code> clause is appearing in a subquery it can’t refer to columns in the parent query.</li>
 </ul></li>
 </ul>
 <h3 id="schema-regions">Schema Regions</h3>
 <p>We touched briefly on schema regions earlier in this section. The purpose and language for regions is described more fully in <a href="https://cgsql.dev/cql-guide/ch10#schema-regions">Chapter 10</a> of the Guide. In this section we’ll deal with how they are implemented and what you should expect to see in the code.</p>
-<p>When a region declaration is found this method is used.</p>
+<p>When a region declaration is found this method is used:</p>
 <div class="sourceCode" id="cb80"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb80-1"><a href="#cb80-1" aria-hidden="true" tabindex="-1"></a><span class="co">// A schema region is an partitioning of the schema such that it</span></span>
 <span id="cb80-2"><a href="#cb80-2" aria-hidden="true" tabindex="-1"></a><span class="co">// only uses objects in the same partition or one of its declared</span></span>
 <span id="cb80-3"><a href="#cb80-3" aria-hidden="true" tabindex="-1"></a><span class="co">// dependencies.  One schema region may be upgraded independently</span></span>
@@ -1947,17 +1982,17 @@ AST(or)</code></pre>
 <span id="cb80-6"><a href="#cb80-6" aria-hidden="true" tabindex="-1"></a><span class="co">//  * the region name is unique</span></span>
 <span id="cb80-7"><a href="#cb80-7" aria-hidden="true" tabindex="-1"></a><span class="co">//  * the dependencies (if any) are unique and exist</span></span>
 <span id="cb80-8"><a href="#cb80-8" aria-hidden="true" tabindex="-1"></a><span class="dt">static</span> <span class="dt">void</span> sem_declare_schema_region_stmt<span class="op">(</span>ast_node <span class="op">*</span>ast<span class="op">)</span>  <span class="op">{</span> <span class="op">...</span> <span class="op">}</span></span></code></pre></div>
-<p>The general rules are described in the comment, but effectively it accumulates the list of this regions dependencies. Sometimes these are called the antecedent regions. Since a region can only depend on other regions that have already been declared, it’s not possible to make any cycles. Regions are declared before you put anything into them.</p>
-<p>Pieces of schema or procedures (or anything really) can go into a region by putting it in a begin/end pair for the name region.</p>
+<p>The general rules are described in the comment, but effectively it accumulates the list of the declared region’s dependencies. Sometimes these are called the antecedent regions. Since a region can only depend on regions that have already been declared, it’s not possible to make any cycles. Regions are declared before you put anything into them.</p>
+<p>Pieces of schema or procedures (or anything really) can go into a region by putting that code inside a begin/end pair for the named region. Like so:</p>
 <div class="sourceCode" id="cb81"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb81-1"><a href="#cb81-1" aria-hidden="true" tabindex="-1"></a><span class="ot">@begin_schema_region your_region;</span></span>
 <span id="cb81-2"><a href="#cb81-2" aria-hidden="true" tabindex="-1"></a>  <span class="co">-- your stuff</span></span>
 <span id="cb81-3"><a href="#cb81-3" aria-hidden="true" tabindex="-1"></a><span class="ot">@end_schema_region;</span></span></code></pre></div>
 <p>Now whatever happens to be in “your stuff” is:</p>
 <ul>
-<li>limited to seeing only the things that <code>your_region</code> is allowed to see and</li>
+<li>limited to seeing only the things that <code>your_region</code> is allowed to see, and</li>
 <li>contributes its contents to <code>your_region</code> thereby limiting how others will be able to use “your stuff”</li>
 </ul>
-<p>To see how this happens, let’s have a look at <code>sem_begin_schema_region_stmt</code></p>
+<p>To see how this happens, let’s have a look at <code>sem_begin_schema_region_stmt</code>.</p>
 <div class="sourceCode" id="cb82"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb82-1"><a href="#cb82-1" aria-hidden="true" tabindex="-1"></a><span class="co">// Entering a schema region makes all the objects that follow part of that</span></span>
 <span id="cb82-2"><a href="#cb82-2" aria-hidden="true" tabindex="-1"></a><span class="co">// region.  It also means that all the contained objects must refer to</span></span>
 <span id="cb82-3"><a href="#cb82-3" aria-hidden="true" tabindex="-1"></a><span class="co">// only pieces of schema that are in the same region or a dependent region.</span></span>
@@ -2002,37 +2037,44 @@ AST(or)</code></pre>
 <span id="cb82-42"><a href="#cb82-42" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span></code></pre></div>
 <p>We see these basic steps:</p>
 <ul>
-<li><code>EXTRACT</code> the region name</li>
-<li><code>verify_schema_region_out_of_proc</code> makes sure we are out of any procedure (we have to be at the top level)
+<li><code>EXTRACT</code> : gets the region name</li>
+<li><code>verify_schema_region_out_of_proc</code> : makes sure we are out of any procedure (we have to be at the top level)
 <ul>
 <li>errors if in a procedure</li>
 </ul></li>
-<li><code>current_region</code> is tested to make sure we are not already in a region (no nesting)
+<li><code>current_region</code> : is tested to make sure we are not already in a region (no nesting)
 <ul>
 <li>errors if already in a region</li>
 </ul></li>
-<li><code>find_region</code> is used to find the region AST by name
+<li><code>find_region</code> : is used to find the region AST by name
 <ul>
 <li>errors if the region name isn’t valid</li>
 </ul></li>
-<li><code>EXTRACT</code> is used again to get the canoncial name of the region
+<li><code>EXTRACT</code> : is used again to get the canonical name of the region
 <ul>
-<li>you could say <code>@begin_schema_region YoUr_ReGION;</code> we want the canonical name <code>your_region</code> as it was declared</li>
+<li>you could write <code>@begin_schema_region YoUr_ReGION;</code> but we want the canonical name <code>your_region</code>, as it was declared</li>
 </ul></li>
-<li><code>symtab_new</code> creates a new symbol table <code>current_region_image</code></li>
-<li><code>sem_accumulate_public_region_image</code> populates <code>current_region_image</code> by recursively walking this region adding the names of all the regions we find along the way
+<li><code>symtab_new</code> : creates a new symbol table <code>current_region_image</code></li>
+<li><code>sem_accumulate_public_region_image</code> : populates <code>current_region_image</code> by recursively walking this region adding the names of all the regions we find along the way
 <ul>
-<li>note the regions form a DAG so we might find the same name twice, we can stop if we find a region that is already in the symbol table</li>
+<li>note the regions form a DAG so we might find the same name twice, we can stop if we find a region that is already in the image symbol table</li>
 </ul></li>
-<li><code>current_region</code> is set to the now new current region</li>
+<li><code>current_region</code> : set it to the now new current region</li>
 </ul>
-<p>Now we’re all set up. * We can use <code>current_region</code> to set the region name in the <code>sem_node</code> of anything we encounter * We can use <code>current_region_image</code> to quickly see if we are allowed to use any given region (if it’s in the table we can use it)</p>
+<p>Now we’re all set up.</p>
+<ul>
+<li>We can use <code>current_region</code> to set the <code>region</code> in the <code>sem_node</code> of anything we encounter</li>
+<li>We can use <code>current_region_image</code> to quickly see if we are allowed to use any given region
+<ul>
+<li>if it’s in the symbol table we can use it</li>
+</ul></li>
+</ul>
 <p>Recall that at the end of <code>sem_create_table_stmt</code> we do this:</p>
 <div class="sourceCode" id="cb83"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb83-1"><a href="#cb83-1" aria-hidden="true" tabindex="-1"></a>  ast<span class="op">-&gt;</span>sem <span class="op">=</span> new_sem<span class="op">(</span>SEM_TYPE_STRUCT<span class="op">);</span></span>
 <span id="cb83-2"><a href="#cb83-2" aria-hidden="true" tabindex="-1"></a>  ast<span class="op">-&gt;</span>sem<span class="op">-&gt;</span>sptr <span class="op">=</span> sptr<span class="op">;</span></span>
 <span id="cb83-3"><a href="#cb83-3" aria-hidden="true" tabindex="-1"></a>  ast<span class="op">-&gt;</span>sem<span class="op">-&gt;</span>jptr <span class="op">=</span> sem_join_from_sem_struct<span class="op">(</span>sptr<span class="op">);</span></span>
 <span id="cb83-4"><a href="#cb83-4" aria-hidden="true" tabindex="-1"></a>  ast<span class="op">-&gt;</span>sem<span class="op">-&gt;</span>region <span class="op">=</span> current_region<span class="op">;</span></span></code></pre></div>
-<p>Which should make a lot more sense now.</p>
+<p>That should make a lot more sense now.</p>
 <p>When doing the symmetric check in <code>sem_validate_object_ast_in_current_region</code> we see this pattern:</p>
 <div class="sourceCode" id="cb84"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb84-1"><a href="#cb84-1" aria-hidden="true" tabindex="-1"></a><span class="co">// Validate whether or not an object is usable with a schema region. The object</span></span>
 <span id="cb84-2"><a href="#cb84-2" aria-hidden="true" tabindex="-1"></a><span class="co">// can only be a table, view, trigger or index.</span></span>
@@ -2076,7 +2118,7 @@ AST(or)</code></pre>
 </ul>
 <p>This is enough to do all the region validation we need.</p>
 <h3 id="results-of-semantic-analysis">Results of Semantic Analysis</h3>
-<p>Semantic Analysis leaves a lot of global state ready for the remaining stages to harvest. If the state is defined in <code>sem.h</code> then it’s ok to harvest. We’ll highlight some of the most important things you can use. These are heavily used in the code generators.</p>
+<p>Semantic Analysis leaves a lot of global state ready for the remaining stages to harvest. If the state is defined in <code>sem.h</code> then it’s ok to harvest. Here we’ll highlight some of the most important things you can use in later passes. These are heavily used in the code generators.</p>
 <div class="sourceCode" id="cb85"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb85-1"><a href="#cb85-1" aria-hidden="true" tabindex="-1"></a>cql_data_decl<span class="op">(</span> <span class="kw">struct</span> list_item <span class="op">*</span>all_tables_list <span class="op">);</span></span>
 <span id="cb85-2"><a href="#cb85-2" aria-hidden="true" tabindex="-1"></a>cql_data_decl<span class="op">(</span> <span class="kw">struct</span> list_item <span class="op">*</span>all_functions_list <span class="op">);</span></span>
 <span id="cb85-3"><a href="#cb85-3" aria-hidden="true" tabindex="-1"></a>cql_data_decl<span class="op">(</span> <span class="kw">struct</span> list_item <span class="op">*</span>all_views_list <span class="op">);</span></span>
@@ -2086,7 +2128,7 @@ AST(or)</code></pre>
 <span id="cb85-7"><a href="#cb85-7" aria-hidden="true" tabindex="-1"></a>cql_data_decl<span class="op">(</span> <span class="kw">struct</span> list_item <span class="op">*</span>all_ad_hoc_list <span class="op">);</span></span>
 <span id="cb85-8"><a href="#cb85-8" aria-hidden="true" tabindex="-1"></a>cql_data_decl<span class="op">(</span> <span class="kw">struct</span> list_item <span class="op">*</span>all_select_functions_list <span class="op">);</span></span>
 <span id="cb85-9"><a href="#cb85-9" aria-hidden="true" tabindex="-1"></a>cql_data_decl<span class="op">(</span> <span class="kw">struct</span> list_item <span class="op">*</span>all_enums_list <span class="op">);</span></span></code></pre></div>
-<p>These linked lists are authoritiative, they let you easily enumerate all the objects of the specified type. If you wanted to do some validation of all indices you could simply walk the all indices list.</p>
+<p>These linked lists are authoritiative, they let you easily enumerate all the objects of the specified type. For instance, if you wanted to do some validation of all indices you could simply walk <code>all_indices_list</code>.</p>
 <div class="sourceCode" id="cb86"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb86-1"><a href="#cb86-1" aria-hidden="true" tabindex="-1"></a>cql_noexport ast_node <span class="op">*</span>find_proc<span class="op">(</span>CSTR name<span class="op">);</span></span>
 <span id="cb86-2"><a href="#cb86-2" aria-hidden="true" tabindex="-1"></a>cql_noexport ast_node <span class="op">*</span>find_region<span class="op">(</span>CSTR name<span class="op">);</span></span>
 <span id="cb86-3"><a href="#cb86-3" aria-hidden="true" tabindex="-1"></a>cql_noexport ast_node <span class="op">*</span>find_func<span class="op">(</span>CSTR name<span class="op">);</span></span>
@@ -2134,11 +2176,11 @@ AST(or)</code></pre>
 <ul>
 <li>errors are reported largely in the AST and percolate up</li>
 <li>expressions and statements have general purpose dispatch logic for continuing a statement walk</li>
-<li>EXTRACT macros are used to keep the tree walk on track and correct in the face of changes</li>
+<li><code>EXTRACT</code> macros are used to keep the tree walk on track and correct in the face of changes</li>
 <li>regions are used for visibility</li>
 <li>versioning contributes to visibility</li>
 <li>nullability and sensitivity are tracked throughout using type bits</li>
-<li>type kind is managed by a simple string in the <code>sem_node</code> payload</li>
+<li>type “kind” is managed by a simple string in the <code>sem_node</code> payload</li>
 <li>the three main payloads are
 <ul>
 <li><code>sem_node</code> for basic info, and</li>
@@ -2154,7 +2196,7 @@ AST(or)</code></pre>
 -- LICENSE file in the root directory of this source tree.
 -->
 <h3 id="preface-2">Preface</h3>
-<p>Part 3 continues with a discussion of the essentials of the C code generation pass of the CQL compiler. As in the previous sections, the goal here is not to go over every detail of code generation but rather to give a sense of how codegen happens in general – the core strategies and implementation choices – so that when reading the code you have an idea how smaller pieces would fit into the whole. To accomplish this, various key data structures will be explained in detail as well as selected examples of their use.</p>
+<p>Part 3 continues with a discussion of the essentials of the C code generation pass of the CQL compiler. As in the previous sections, the goal here is not to go over every detail of code generation but rather to give a sense of how codegen happens in general – the core strategies and implementation choices – so that when reading the code you will have an idea how smaller pieces would fit into the whole. To accomplish this, various key data structures will be explained in detail as well as selected examples of their use.</p>
 <h2 id="c-code-generation">C Code Generation</h2>
 <p>There are several key pieces of C code that we have to generate to make working CQL procedures using C functions. This all happens in <code>cg_c.c</code>. From a big picture perspective, these are the essential problems:</p>
 <ul>
@@ -2180,19 +2222,19 @@ AST(or)</code></pre>
 </ul></li>
 <li>we have to produce a <code>.h</code> and a <code>.c</code> file for the C compiler
 <ul>
-<li>contributions to these files could come from various places</li>
+<li>contributions to these files could come from various places, not necessarily in order</li>
 <li>the <code>.c</code> file will itself have various sections and we might need to contribute to them at various points in the compilation</li>
 </ul></li>
 <li>we want to do this all in one pass over the AST</li>
-<li>we get to assume that the program is error free, codegen never runs unless semantic analysis reports zero errors
+<li>we get to assume that the program is error-free – codegen never runs unless semantic analysis reports zero errors
 <ul>
 <li>so nothing can be wrong by the time the codegen pass runs, we never detect errors here</li>
-<li>sometimes we add <code>Contract</code> and <code>Invariant</code> statements to <code>cg.c</code> that make our assumptions clear and prevent regressions</li>
+<li>sometimes we add <code>Contract</code> and <code>Invariant</code> statements to <code>cg.c</code> to make our assumptions clear and to prevent regressions</li>
 </ul></li>
 </ul>
-<p>There are some very important building blocks used to solve these problems we will start with those, then move to a discussion of each of the essential kinds of code generation that we have to do to get working programs.</p>
+<p>There are some very important building blocks used to solve these problems: we will start with those, then move to a discussion of each of the essential kinds of code generation that we have to do to get working programs.</p>
 <h3 id="launching-the-code-generator">Launching the Code Generator</h3>
-<p>Once semantic analysis is done all of the code generators have the same contract: they have a main function like <code>cg_c_main</code> for the C code generator. It gets the root of the AST and it can use the public interface of the semantic analyzer to get additional information. See <a href="https://cgsql.dev/cql-guide/int02">Part 2</a> for those details.</p>
+<p>Once semantic analysis is done, all of the code generators have the same contract: they have a main function like <code>cg_c_main</code> for the C code generator. It gets the root of the AST and it can use the public interface of the semantic analyzer to get additional information. See <a href="https://cgsql.dev/cql-guide/int02">Part 2</a> for those details.</p>
 <div class="sourceCode" id="cb88"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb88-1"><a href="#cb88-1" aria-hidden="true" tabindex="-1"></a><span class="co">// Main entry point for code-gen.  This will set up the buffers for the global</span></span>
 <span id="cb88-2"><a href="#cb88-2" aria-hidden="true" tabindex="-1"></a><span class="co">// variables and any loose calls or DML.  Any code that needs to run in the</span></span>
 <span id="cb88-3"><a href="#cb88-3" aria-hidden="true" tabindex="-1"></a><span class="co">// global scope will be added to the global_proc.  This is the only codegen</span></span>
@@ -2220,21 +2262,21 @@ AST(or)</code></pre>
   STD_DML_STMT_INIT(rollback_trans_stmt);
   STD_DML_STMT_INIT(savepoint_stmt);
   STD_DML_STMT_INIT(delete_stmt);</code></pre>
-<p>They are handled by <code>cg_std_dml_exec_stmt</code>; the processing is identical to DDL except <code>CG_MINIFY_ALIASES</code> is specified. This allows the code generator to remove unused column aliases in select statements to save space.</p>
+<p>The DML statements are handled by <code>cg_std_dml_exec_stmt</code>; the processing is identical to DDL except <code>CG_MINIFY_ALIASES</code> is specified. This allows the code generator to remove unused column aliases in <code>SELECT</code> statements to save space.</p>
 <pre><code>// Straight up DML invocation.  The ast has the statement, execute it!
 static void cg_std_dml_exec_stmt(ast_node *ast) {
   cg_bound_sql_statement(NULL, ast, CG_EXEC|CG_MINIFY_ALIASES);
 }</code></pre>
-<p>Note that this flag difference only matters for the <code>create view</code> statement but for symmetry all the DDL is handled with one macro and all the DML with the second macro.</p>
-<p>Next, the easiest case… there are a bunch of statements that create no code-gen at all. These are type defintions that are interesting only to the semantic analyzer or other control statements. Some examples:</p>
+<p>Note that this flag difference only matters for the <code>CREATE VIEW</code> statement but for symmetry all the DDL is handled with one macro and all the DML with the second macro.</p>
+<p>Next, the easiest case… there are a bunch of statements that create no code-gen at all. These statements are type definitions that are interesting only to the semantic analyzer, or other control statements. Some examples:</p>
 <div class="sourceCode" id="cb93"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb93-1"><a href="#cb93-1" aria-hidden="true" tabindex="-1"></a>  NO_OP_STMT_INIT<span class="op">(</span>declare_enum_stmt<span class="op">);</span></span>
 <span id="cb93-2"><a href="#cb93-2" aria-hidden="true" tabindex="-1"></a>  NO_OP_STMT_INIT<span class="op">(</span>declare_named_type<span class="op">);</span></span></code></pre></div>
-<p>Next, the general purpose statement handler. This creates a mapping from the <code>if_stmt</code> AST node to <code>cg_if_stmt</code>.</p>
+<p>Next, the general purpose statement handler. <code>STMT_INIT</code> creates mappings such as the <code>if_stmt</code> AST node mapping to <code>cg_if_stmt</code>.</p>
 <div class="sourceCode" id="cb94"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb94-1"><a href="#cb94-1" aria-hidden="true" tabindex="-1"></a>  STMT_INIT<span class="op">(</span>if_stmt<span class="op">);</span></span>
 <span id="cb94-2"><a href="#cb94-2" aria-hidden="true" tabindex="-1"></a>  STMT_INIT<span class="op">(</span>switch_stmt<span class="op">);</span></span>
 <span id="cb94-3"><a href="#cb94-3" aria-hidden="true" tabindex="-1"></a>  STMT_INIT<span class="op">(</span>while_stmt<span class="op">);</span></span>
 <span id="cb94-4"><a href="#cb94-4" aria-hidden="true" tabindex="-1"></a>  STMT_INIT<span class="op">(</span>assign<span class="op">);</span></span></code></pre></div>
-<p>The next group is the expressions, with precedence and operator specified. There is a lot of code sharing as you can see from this sample:</p>
+<p>The next group of declarations arethe expressions, with precedence and operator specified. There is a lot of code sharing between AST types as you can see from this sample:</p>
 <div class="sourceCode" id="cb95"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb95-1"><a href="#cb95-1" aria-hidden="true" tabindex="-1"></a>  EXPR_INIT<span class="op">(</span>num<span class="op">,</span> cg_expr_num<span class="op">,</span> <span class="st">&quot;num&quot;</span><span class="op">,</span> C_EXPR_PRI_ROOT<span class="op">);</span></span>
 <span id="cb95-2"><a href="#cb95-2" aria-hidden="true" tabindex="-1"></a>  EXPR_INIT<span class="op">(</span>str<span class="op">,</span> cg_expr_str<span class="op">,</span> <span class="st">&quot;STR&quot;</span><span class="op">,</span> C_EXPR_PRI_ROOT<span class="op">);</span></span>
 <span id="cb95-3"><a href="#cb95-3" aria-hidden="true" tabindex="-1"></a>  EXPR_INIT<span class="op">(</span>null<span class="op">,</span> cg_expr_null<span class="op">,</span> <span class="st">&quot;NULL&quot;</span><span class="op">,</span> C_EXPR_PRI_ROOT<span class="op">);</span></span>
@@ -2249,8 +2291,8 @@ static void cg_std_dml_exec_stmt(ast_node *ast) {
 <span id="cb95-12"><a href="#cb95-12" aria-hidden="true" tabindex="-1"></a>  EXPR_INIT<span class="op">(</span>tilde<span class="op">,</span> cg_unary<span class="op">,</span> <span class="st">&quot;~&quot;</span><span class="op">,</span> C_EXPR_PRI_UNARY<span class="op">);</span></span>
 <span id="cb95-13"><a href="#cb95-13" aria-hidden="true" tabindex="-1"></a>  EXPR_INIT<span class="op">(</span>uminus<span class="op">,</span> cg_unary<span class="op">,</span> <span class="st">&quot;-&quot;</span><span class="op">,</span> C_EXPR_PRI_UNARY<span class="op">);</span></span></code></pre></div>
 <p>Most (not all) of the binary operators are handled with one function <code>cg_binary</code> and likewise most unary operators are handled with <code>cg_unary</code>.</p>
-<p>Note: the precedence constants are the <code>C_EXPR_PRI_*</code> flavor because parentheses will be generated based on the C rules at this point. Importantly, the AST still, and always has the user-specified order of operations encoded in it, there’s no change there. The only thing that changes is where parentheses are needed to get the desired result. Parens may need to be added and some that were present in the original text might no longer be needed.</p>
-<p>e.g.</p>
+<p>Note: the precedence constants are the <code>C_EXPR_PRI_*</code> flavor because, naturally, parentheses will be generated based on the C rules during C codegen. Importantly, the AST still, and always, authoritatively encodes the user-specified order of operations – there’s no change there. The only thing that changes is where parentheses are needed to get the desired result. Some parens may need to be added, and some that were present in the original text might no longer be needed.</p>
+<p>Here are some helpful examples:</p>
 <div class="sourceCode" id="cb96"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb96-1"><a href="#cb96-1" aria-hidden="true" tabindex="-1"></a><span class="kw">CREATE</span> PROC p ()</span>
 <span id="cb96-2"><a href="#cb96-2" aria-hidden="true" tabindex="-1"></a><span class="cf">BEGIN</span></span>
 <span id="cb96-3"><a href="#cb96-3" aria-hidden="true" tabindex="-1"></a>  <span class="co">/* NOT is weaker than + */</span></span>
@@ -2264,13 +2306,13 @@ static void cg_std_dml_exec_stmt(ast_node *ast) {
 <span id="cb97-5"><a href="#cb97-5" aria-hidden="true" tabindex="-1"></a>  x <span class="op">=</span> <span class="op">!</span> <span class="dv">1</span> <span class="op">+</span> <span class="op">!</span> <span class="dv">2</span><span class="op">;</span></span>
 <span id="cb97-6"><a href="#cb97-6" aria-hidden="true" tabindex="-1"></a>  x <span class="op">=</span> <span class="op">!</span> <span class="op">(</span><span class="dv">1</span> <span class="op">+</span> <span class="dv">2</span><span class="op">);</span></span>
 <span id="cb97-7"><a href="#cb97-7" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span></code></pre></div>
-<p>Finally, many built-in functions need special codegen.</p>
+<p>Finally, many built-in functions need special codegen, such as:</p>
 <div class="sourceCode" id="cb98"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb98-1"><a href="#cb98-1" aria-hidden="true" tabindex="-1"></a>  FUNC_INIT<span class="op">(</span>coalesce<span class="op">);</span></span>
 <span id="cb98-2"><a href="#cb98-2" aria-hidden="true" tabindex="-1"></a>  FUNC_INIT<span class="op">(</span>printf<span class="op">);</span></span></code></pre></div>
 <p><code>FUNC_INIT(coalesce)</code> creates a mapping between the function name <code>coalesce</code> and the generator <code>cg_func_coalesce</code>.</p>
 <h3 id="character-buffers-and-byte-buffers">Character Buffers and Byte Buffers</h3>
-<p>The first kind of text output that CQL could produce was the AST echoing. This was original done directly with <code>fprintf</code> but that was not flexible enough as the output had to be captured to be emitted into other places like comments or the text of SQL statements to go to SQLite. This forces that pass to use character buffers, which we touched on in Part 1. Code generation has a more profound dependency on character buffers – they are literally all over <code>cg_c.c</code> and we need to go over how hey are used.</p>
-<p>The public interace is in <code>charbuf.h</code> and it’s really quite simple. You allocate a <code>charbuf</code> and then you can <code>bprintf</code> into it. Let’s be a bit more specific:</p>
+<p>The first kind of text output that CQL could produce was the AST echoing. This was originally done directly with <code>fprintf</code> but that was never going to be flexible enough – we have to be able to emitt that output into other places like comments, or the text of SQL statements. This need forces that pass to use character buffers, which we touched on in Part 1. C Code generation has a more profound dependency on character buffers – they are literally all over <code>cg_c.c</code> and we need to go over how they are used if we’re going to understand the codegen passes.</p>
+<p>The public interface for <code>charbuf</code> is in <code>charbuf.h</code> and it’s really quite simple. You allocate a <code>charbuf</code> and then you can <code>bprintf</code> into it. Let’s be a bit more specific:</p>
 <div class="sourceCode" id="cb99"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb99-1"><a href="#cb99-1" aria-hidden="true" tabindex="-1"></a><span class="pp">#define CHARBUF_INTERNAL_SIZE 1024</span></span>
 <span id="cb99-2"><a href="#cb99-2" aria-hidden="true" tabindex="-1"></a><span class="pp">#define CHARBUF_GROWTH_SIZE 1024</span></span>
 <span id="cb99-3"><a href="#cb99-3" aria-hidden="true" tabindex="-1"></a></span>
@@ -2295,8 +2337,8 @@ static void cg_std_dml_exec_stmt(ast_node *ast) {
 <span id="cb100-3"><a href="#cb100-3" aria-hidden="true" tabindex="-1"></a>  bprintf<span class="op">(&amp;</span>foo<span class="op">,</span> <span class="st">&quot;Hello %s</span><span class="sc">\n</span><span class="st">&quot;</span><span class="op">,</span> <span class="st">&quot;World&quot;</span><span class="op">);</span></span>
 <span id="cb100-4"><a href="#cb100-4" aria-hidden="true" tabindex="-1"></a>  <span class="co">// do something with foo.ptr</span></span>
 <span id="cb100-5"><a href="#cb100-5" aria-hidden="true" tabindex="-1"></a>  bclose<span class="op">(&amp;</span>foo<span class="op">);</span></span></code></pre></div>
-<p>Note that <code>charbuf</code> includes <code>CHARBUF_INTERNAL_SIZE</code> of storage that does not have to be allocated with <code>malloc</code> and it doesn’t grow very aggressively. This reflects that fact that most <code>charbuf</code> instances are very small. Of course a <code>charbuf</code> could go on the heap if it needs to outlive the function it appears in, but this is exceedingly rare.</p>
-<p>To make sure buffers are consistently closed (and this is a problem because there are often a lot of them. They are allocated with these simple helper macros.</p>
+<p>Note that <code>charbuf</code> includes <code>CHARBUF_INTERNAL_SIZE</code> of storage that does not have to be allocated with <code>malloc</code> and it doesn’t grow very aggressively. This economy reflects that fact that most <code>charbuf</code> instances are very small. Of course a <code>charbuf</code> could go on the heap if it needs to outlive the function it appears in, but this is exceedingly rare.</p>
+<p>To make sure buffers are consistently closed – and this is a problem because there are often a lot of them – they are allocated with these simple helper macros:</p>
 <div class="sourceCode" id="cb101"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb101-1"><a href="#cb101-1" aria-hidden="true" tabindex="-1"></a><span class="pp">#define CHARBUF_OPEN(x) \</span></span>
 <span id="cb101-2"><a href="#cb101-2" aria-hidden="true" tabindex="-1"></a><span class="pp">  int32_t __saved_charbuf_count##x = charbuf_open_count; \</span></span>
 <span id="cb101-3"><a href="#cb101-3" aria-hidden="true" tabindex="-1"></a><span class="pp">  charbuf x; \</span></span>
@@ -2305,43 +2347,46 @@ static void cg_std_dml_exec_stmt(ast_node *ast) {
 <span id="cb101-6"><a href="#cb101-6" aria-hidden="true" tabindex="-1"></a><span class="pp">#define CHARBUF_CLOSE(x) \</span></span>
 <span id="cb101-7"><a href="#cb101-7" aria-hidden="true" tabindex="-1"></a><span class="pp">  bclose(&amp;x); \</span></span>
 <span id="cb101-8"><a href="#cb101-8" aria-hidden="true" tabindex="-1"></a><span class="pp">  Invariant(__saved_charbuf_count##x == charbuf_open_count)</span></span></code></pre></div>
-<p>the earlier example would be written more properly:</p>
+<p>The earlier example would be written more properly:</p>
 <div class="sourceCode" id="cb102"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb102-1"><a href="#cb102-1" aria-hidden="true" tabindex="-1"></a>  CHARBUF_OPEN<span class="op">(</span>foo<span class="op">);</span></span>
 <span id="cb102-2"><a href="#cb102-2" aria-hidden="true" tabindex="-1"></a>    bprintf<span class="op">(&amp;</span>foo<span class="op">,</span> <span class="st">&quot;Hello %s</span><span class="sc">\n</span><span class="st">&quot;</span><span class="op">,</span> <span class="st">&quot;World&quot;</span><span class="op">);</span></span>
 <span id="cb102-3"><a href="#cb102-3" aria-hidden="true" tabindex="-1"></a>    <span class="co">// do something with foo.ptr</span></span>
 <span id="cb102-4"><a href="#cb102-4" aria-hidden="true" tabindex="-1"></a>  CHARBUF_CLOSE<span class="op">(</span>foo<span class="op">);</span></span></code></pre></div>
 <p>If you forget to close a buffer the count will get messed up and the next close will trigger an assertion failure.</p>
-<p>It’s normal to create several buffers in the course of doing code generation. In fact some of these buffers become “globally” visible and get swapped out as needed. For instance this kind of chaining is normal. Inside of <code>cg_create_proc_stmt</code> there is these sequence:</p>
+<p>It’s normal to create several buffers in the course of doing code generation. In fact some of these buffers become “globally” visible and get swapped out as needed. For instance, the kind of chaining we see inside of <code>cg_create_proc_stmt</code> is normal, here is the sequence:</p>
 <p>Make new buffers…</p>
 <div class="sourceCode" id="cb103"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb103-1"><a href="#cb103-1" aria-hidden="true" tabindex="-1"></a>  CHARBUF_OPEN<span class="op">(</span>proc_fwd_ref<span class="op">);</span></span>
 <span id="cb103-2"><a href="#cb103-2" aria-hidden="true" tabindex="-1"></a>  CHARBUF_OPEN<span class="op">(</span>proc_body<span class="op">);</span></span>
 <span id="cb103-3"><a href="#cb103-3" aria-hidden="true" tabindex="-1"></a>  CHARBUF_OPEN<span class="op">(</span>proc_locals<span class="op">);</span></span>
 <span id="cb103-4"><a href="#cb103-4" aria-hidden="true" tabindex="-1"></a>  CHARBUF_OPEN<span class="op">(</span>proc_cleanup<span class="op">);</span></span></code></pre></div>
-<p>Save what we got…</p>
+<p>Save the current buffer pointers…</p>
 <div class="sourceCode" id="cb104"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb104-1"><a href="#cb104-1" aria-hidden="true" tabindex="-1"></a>  charbuf <span class="op">*</span>saved_main <span class="op">=</span> cg_main_output<span class="op">;</span></span>
 <span id="cb104-2"><a href="#cb104-2" aria-hidden="true" tabindex="-1"></a>  charbuf <span class="op">*</span>saved_decls <span class="op">=</span> cg_declarations_output<span class="op">;</span></span>
 <span id="cb104-3"><a href="#cb104-3" aria-hidden="true" tabindex="-1"></a>  charbuf <span class="op">*</span>saved_scratch <span class="op">=</span> cg_scratch_vars_output<span class="op">;</span></span>
 <span id="cb104-4"><a href="#cb104-4" aria-hidden="true" tabindex="-1"></a>  charbuf <span class="op">*</span>saved_cleanup <span class="op">=</span> cg_cleanup_output<span class="op">;</span></span>
 <span id="cb104-5"><a href="#cb104-5" aria-hidden="true" tabindex="-1"></a>  charbuf <span class="op">*</span>saved_fwd_ref <span class="op">=</span> cg_fwd_ref_output<span class="op">;</span></span></code></pre></div>
-<p>Switch to the new…</p>
+<p>Switch to the new buffers…</p>
 <div class="sourceCode" id="cb105"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb105-1"><a href="#cb105-1" aria-hidden="true" tabindex="-1"></a>  cg_fwd_ref_output <span class="op">=</span> <span class="op">&amp;</span>proc_fwd_ref<span class="op">;</span></span>
 <span id="cb105-2"><a href="#cb105-2" aria-hidden="true" tabindex="-1"></a>  cg_main_output <span class="op">=</span> <span class="op">&amp;</span>proc_body<span class="op">;</span></span>
 <span id="cb105-3"><a href="#cb105-3" aria-hidden="true" tabindex="-1"></a>  cg_declarations_output <span class="op">=</span> <span class="op">&amp;</span>proc_locals<span class="op">;</span></span>
 <span id="cb105-4"><a href="#cb105-4" aria-hidden="true" tabindex="-1"></a>  cg_scratch_vars_output <span class="op">=</span> <span class="op">&amp;</span>proc_locals<span class="op">;</span></span>
 <span id="cb105-5"><a href="#cb105-5" aria-hidden="true" tabindex="-1"></a>  cg_cleanup_output <span class="op">=</span> <span class="op">&amp;</span>proc_cleanup<span class="op">;</span></span></code></pre></div>
-<p>And of course the code puts the original values back when it’s done and closes the buffers.</p>
-<p>This means that while processing a procedure the codegen that declares say scratch variables, which would go to <code>cg_scratch_vars_output</code> is going to target the <code>proc_locals</code> buffer which will be emitted before the <code>body</code>. By the time <code>cg_stmt_list</code> is invoked the <code>cg_main_output</code> variable will be pointing to the procedure body, thus any statements will go into there rather than being acculated at the global level – it’s possible to have code that is not in a procedure (see <a href="https://cgsql.dev/cql-guide/x1#--global_proc-name"><code>--global_proc</code></a>).</p>
-<p>But in general, it’s very useful to have different buffers going on at the same time. New local variables or scratch variables can be added to their own buffer which goes before the code runs. New cleanup steps that are necessary can be added to the cleanup output which will appear at the end. The final function combines all of these pieces with maybe some glue. Everything works like this, <code>IF</code> statements, expressions, all of it.</p>
-<p>One interesting but unexpected feature of <code>charbuf</code> is that it provides helper methods for indenting buffer by whatever amount you like. This turns out to be invaluable in creating well formatted C code because of course you want (e.g.) the body of an <code>if</code> statement to be indented. CQL tries to create well formatted code that is readable by humans as much as possible.</p>
+<p>And of course the code puts the original values back when it’s done and then closes what it opened.</p>
+<p>This means that while processing a procedure the codegen that declares say scratch variables, which would go to <code>cg_scratch_vars_output</code>, is going to target the <code>proc_locals</code> buffer which will be emitted before the <code>proc_body</code>. By the time <code>cg_stmt_list</code> is invoked the <code>cg_main_output</code> variable will be pointing to the procedure body, thus any statements will go into there rather than being acculated at the global level.</p>
+<p>Note: it’s possible to have code that is not in a procedure (see <a href="https://cgsql.dev/cql-guide/x1#--global_proc-name"><code>--global_proc</code></a>).</p>
+<p>In general, it’s very useful to have different buffers open at the same time. New local variables or scratch variables can be added to their own buffer. New cleanup steps that are necessary can be added to <code>cg_cleanup_output</code> which will appear at the end of a procedure. The final steps of procedure codegen combines all of these pieces plus a little glue to make a working procedure.</p>
+<p>All codegen works like this – statements, expressions, all of it.</p>
+<p>One interesting but unexpected feature of <code>charbuf</code> is that it provides helper methods for indenting a buffer by whatever amount you like. This turns out to be invaluable in creating well formatted C code because of course we want (e.g.) the body of an <code>if</code> statement to be indented. CQL tries to create well formatted code that is readable by humans as much as possible.</p>
 <h4 id="byte-buffers">Byte Buffers</h4>
-<p>These are less commonly used but there is a peer to <code>charbuf</code> creatively called <code>bytebuf</code>. This gives you a growable binary buffer. It’s often used to hold arrays of structures. Interestingly, <code>cg_c.c</code> doesn’t currently consume byte buffers, the presence of <code>bytebuf.c</code> actually came late to the CQL compiler. However the CQL runtime <code>cqlrt.c</code> (and <code>cqlrt_common.c</code>) provide <code>cql_bytebuf_open</code>, <code>cql_bytebuf_alloc</code> and, <code>cql_bytebuf_close</code> which are akin to the <code>charbuf</code> methods. These functions are used in the generated code to create result sets at runtime. The <code>bytebuf</code> was so useful that it found its way back from the runtime into the compiler itself, and is used by other code-generators like the schema upgrader. The semantic analyzer also uses it to help with query fragments and to track the various upgrade annotations.</p>
-<p>Both <code>charbuf</code> and <code>bytebuf</code> are simple enough that they don’t need discussion. It’s easier to just read the code and the comments.</p>
+<p>The byte buffers type, creatively called <code>bytebuf</code> is less commonly used. It is a peer to <code>charbuf</code> and provides a growable binary buffer. <code>bytebuf</code> is often used to hold arrays of structures. Interestingly, <code>cg_c.c</code> doesn’t currently consume byte buffers, the presence of <code>bytebuf.c</code> actually came late to the CQL compiler. However the CQL runtime <code>cqlrt.c</code> (and <code>cqlrt_common.c</code>) provide <code>cql_bytebuf_open</code>, <code>cql_bytebuf_alloc</code> and, <code>cql_bytebuf_close</code> which are akin to the <code>charbuf</code> methods. These functions <em>are</em> used in the generated code to create result sets at runtime.</p>
+<p><code>bytebuf</code> was so useful that it found its way back from the runtime into the compiler itself, and is used by other code-generators like the schema upgrader. The semantic analyzer also uses it to help with query fragments and to track the various upgrade annotations.</p>
+<p>Both <code>charbuf</code> and <code>bytebuf</code> are simple enough that they don’t need special discussion. Surveying their code and comments is an excellent exercise for the reader.</p>
 <h3 id="expressions">Expressions</h3>
-<p>Many of the output needs of CQL stemmed from the base case of creating expressions. A simple CQL expression like</p>
+<p>Many of the output needs of CQL stemmed from the base case of creating the code for CQL expressions. A simple CQL expression like:</p>
 <div class="sourceCode" id="cb106"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb106-1"><a href="#cb106-1" aria-hidden="true" tabindex="-1"></a>  <span class="kw">SET</span> x <span class="op">:=</span> x <span class="op">+</span> y;</span></code></pre></div>
-<p>seems innocuous enough, we’d like this to compile to this code:</p>
+<p>seems innocuous enough, and we’d like that expression to compile to this code:</p>
 <div class="sourceCode" id="cb107"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb107-1"><a href="#cb107-1" aria-hidden="true" tabindex="-1"></a>  x <span class="op">=</span> x <span class="op">+</span> y<span class="op">;</span></span></code></pre></div>
-<p>And indeed, it might. Here’s some actual output from the compiler:</p>
+<p>And indeed, it does. Here’s some actual output from the compiler:</p>
 <div class="sourceCode" id="cb108"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb108-1"><a href="#cb108-1" aria-hidden="true" tabindex="-1"></a><span class="co">/*</span></span>
 <span id="cb108-2"><a href="#cb108-2" aria-hidden="true" tabindex="-1"></a><span class="co">CREATE PROC p ()</span></span>
 <span id="cb108-3"><a href="#cb108-3" aria-hidden="true" tabindex="-1"></a><span class="re">BEGIN</span></span>
@@ -2359,15 +2404,16 @@ static void cg_std_dml_exec_stmt(ast_node *ast) {
 <span id="cb108-15"><a href="#cb108-15" aria-hidden="true" tabindex="-1"></a></span>
 <span id="cb108-16"><a href="#cb108-16" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span>
 <span id="cb108-17"><a href="#cb108-17" aria-hidden="true" tabindex="-1"></a><span class="pp">#undef _PROC_</span></span></code></pre></div>
-<p>(*) the output above was created by using <code>out/cql --in x --cg x.h x.c --nolines</code> to avoid all the # directives</p>
-<p>Looks easy enough. And indeed if all expressions were like this, you could do expression compilation pretty simply – every binary operator would look something like this:</p>
+<p>(*) the output above was created by using <code>out/cql --in x --cg x.h x.c --nolines</code> to avoid all the <code>#</code> directives</p>
+<p>That expression looks easy enough. And indeed if all expressions were like this, we could do expression compilation pretty simply – every binary operator would look something like this:</p>
 <ul>
 <li>recurse left</li>
 <li>emit infix operator</li>
 <li>recurse right</li>
 </ul>
 <p>This would sort of build up your expressions inside out and your final buffer after all the recursion was done would have the whole expression.</p>
-<p>This doesn’t work at all. To illustrate what goes wrong, we only have to change the test case a tiny bit. The result is telling:</p>
+<p>This doesn’t work at all.</p>
+<p>To illustrate what goes wrong, we only have to change the test case a tiny bit. The result is telling:</p>
 <div class="sourceCode" id="cb109"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb109-1"><a href="#cb109-1" aria-hidden="true" tabindex="-1"></a><span class="co">/*</span></span>
 <span id="cb109-2"><a href="#cb109-2" aria-hidden="true" tabindex="-1"></a><span class="co">CREATE PROC p ()</span></span>
 <span id="cb109-3"><a href="#cb109-3" aria-hidden="true" tabindex="-1"></a><span class="re">BEGIN</span></span>
@@ -2387,36 +2433,42 @@ static void cg_std_dml_exec_stmt(ast_node *ast) {
 <span id="cb109-17"><a href="#cb109-17" aria-hidden="true" tabindex="-1"></a></span>
 <span id="cb109-18"><a href="#cb109-18" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span>
 <span id="cb109-19"><a href="#cb109-19" aria-hidden="true" tabindex="-1"></a><span class="pp">#undef _PROC_</span></span></code></pre></div>
-<p>All that’s happened in the above is that <code>x</code> and <code>y</code> became nullable variables, that is the <code>NOT NULL</code> was removed from the declaration. This makes all the difference in the world, and this is a fairly easy case. The problem is that nullable value types like cql_nullable_int32 have an integer and a boolean and these don’t flow into expressions that use operators like <code>+</code>, <code>-</code>, <code>/</code> and so forth. This means that even simple expressions involving nullable types actually expand into several statements. And, in general, these statements need a place to put their temporary results to accumulate the answer, so scratch variables are required to make all this work.</p>
+<p>In this new example above, <code>x</code> and <code>y</code> became nullable variables i.e. the <code>NOT NULL</code> was removed from their declarations – this makes all the difference in the world.</p>
+<p>Let’s take a quick look at <code>cql_nullable_int32</code> and we’ll see the crux of the problem immediately:</p>
+<div class="sourceCode" id="cb110"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb110-1"><a href="#cb110-1" aria-hidden="true" tabindex="-1"></a><span class="kw">typedef</span> <span class="kw">struct</span> cql_nullable_int32 <span class="op">{</span></span>
+<span id="cb110-2"><a href="#cb110-2" aria-hidden="true" tabindex="-1"></a> cql_bool is_null<span class="op">;</span></span>
+<span id="cb110-3"><a href="#cb110-3" aria-hidden="true" tabindex="-1"></a> cql_int32 value<span class="op">;</span></span>
+<span id="cb110-4"><a href="#cb110-4" aria-hidden="true" tabindex="-1"></a><span class="op">}</span> cql_nullable_int32<span class="op">;</span></span></code></pre></div>
+<p>The problem is that nullable value types like <code>cql_nullable_int32</code> have both their <code>value</code> field and a boolean <code>is_null</code> and these don’t flow into expressions that use operators like <code>+</code>, <code>-</code>, <code>/</code> and so forth. This means that even simple expressions involving nullable types actually expand into several statements. And, in general, these statements need a place to put their temporary results to accumulate the correct answer, so scratch variables are required to make all this work.</p>
 <p>Here’s a more realistic example:</p>
-<div class="sourceCode" id="cb110"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb110-1"><a href="#cb110-1" aria-hidden="true" tabindex="-1"></a><span class="co">/*</span></span>
-<span id="cb110-2"><a href="#cb110-2" aria-hidden="true" tabindex="-1"></a><span class="co">CREATE PROC combine (x INTEGER, y INTEGER, OUT result INTEGER)</span></span>
-<span id="cb110-3"><a href="#cb110-3" aria-hidden="true" tabindex="-1"></a><span class="re">BEGIN</span></span>
-<span id="cb110-4"><a href="#cb110-4" aria-hidden="true" tabindex="-1"></a><span class="co">  SET result := 5 * x + 3 * y;</span></span>
-<span id="cb110-5"><a href="#cb110-5" aria-hidden="true" tabindex="-1"></a><span class="re">END</span><span class="co">;</span></span>
-<span id="cb110-6"><a href="#cb110-6" aria-hidden="true" tabindex="-1"></a><span class="co">*/</span></span>
-<span id="cb110-7"><a href="#cb110-7" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb110-8"><a href="#cb110-8" aria-hidden="true" tabindex="-1"></a><span class="pp">#define _PROC_ &quot;combine&quot;</span></span>
-<span id="cb110-9"><a href="#cb110-9" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> combine<span class="op">(</span>cql_nullable_int32 x<span class="op">,</span> cql_nullable_int32 y<span class="op">,</span> cql_nullable_int32 <span class="op">*</span>_Nonnull result<span class="op">)</span> <span class="op">{</span></span>
-<span id="cb110-10"><a href="#cb110-10" aria-hidden="true" tabindex="-1"></a>  cql_contract_argument_notnull<span class="op">((</span><span class="dt">void</span> <span class="op">*)</span>result<span class="op">,</span> <span class="dv">3</span><span class="op">);</span></span>
-<span id="cb110-11"><a href="#cb110-11" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb110-12"><a href="#cb110-12" aria-hidden="true" tabindex="-1"></a>  cql_nullable_int32 _tmp_n_int_1<span class="op">;</span></span>
-<span id="cb110-13"><a href="#cb110-13" aria-hidden="true" tabindex="-1"></a>  cql_set_null<span class="op">(</span>_tmp_n_int_1<span class="op">);</span></span>
-<span id="cb110-14"><a href="#cb110-14" aria-hidden="true" tabindex="-1"></a>  cql_nullable_int32 _tmp_n_int_2<span class="op">;</span></span>
-<span id="cb110-15"><a href="#cb110-15" aria-hidden="true" tabindex="-1"></a>  cql_set_null<span class="op">(</span>_tmp_n_int_2<span class="op">);</span></span>
-<span id="cb110-16"><a href="#cb110-16" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb110-17"><a href="#cb110-17" aria-hidden="true" tabindex="-1"></a>  cql_set_null<span class="op">(*</span>result<span class="op">);</span> <span class="co">// set out arg to non-garbage</span></span>
-<span id="cb110-18"><a href="#cb110-18" aria-hidden="true" tabindex="-1"></a>  cql_set_nullable<span class="op">(</span>_tmp_n_int_1<span class="op">,</span> x<span class="op">.</span>is_null<span class="op">,</span> <span class="dv">5</span> <span class="op">*</span> x<span class="op">.</span>value<span class="op">);</span></span>
-<span id="cb110-19"><a href="#cb110-19" aria-hidden="true" tabindex="-1"></a>  cql_set_nullable<span class="op">(</span>_tmp_n_int_2<span class="op">,</span> y<span class="op">.</span>is_null<span class="op">,</span> <span class="dv">3</span> <span class="op">*</span> y<span class="op">.</span>value<span class="op">);</span></span>
-<span id="cb110-20"><a href="#cb110-20" aria-hidden="true" tabindex="-1"></a>  cql_combine_nullables<span class="op">(*</span>result<span class="op">,</span> _tmp_n_int_1<span class="op">.</span>is_null<span class="op">,</span> _tmp_n_int_2<span class="op">.</span>is_null<span class="op">,</span> _tmp_n_int_1<span class="op">.</span>value <span class="op">+</span> _tmp_n_int_2<span class="op">.</span>value<span class="op">);</span></span>
-<span id="cb110-21"><a href="#cb110-21" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb110-22"><a href="#cb110-22" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span>
-<span id="cb110-23"><a href="#cb110-23" aria-hidden="true" tabindex="-1"></a><span class="pp">#undef _PROC_</span></span>
-<span id="cb110-24"><a href="#cb110-24" aria-hidden="true" tabindex="-1"></a><span class="pp">#pragma clang diagnostic pop</span></span></code></pre></div>
+<div class="sourceCode" id="cb111"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb111-1"><a href="#cb111-1" aria-hidden="true" tabindex="-1"></a><span class="co">/*</span></span>
+<span id="cb111-2"><a href="#cb111-2" aria-hidden="true" tabindex="-1"></a><span class="co">CREATE PROC combine (x INTEGER, y INTEGER, OUT result INTEGER)</span></span>
+<span id="cb111-3"><a href="#cb111-3" aria-hidden="true" tabindex="-1"></a><span class="re">BEGIN</span></span>
+<span id="cb111-4"><a href="#cb111-4" aria-hidden="true" tabindex="-1"></a><span class="co">  SET result := 5 * x + 3 * y;</span></span>
+<span id="cb111-5"><a href="#cb111-5" aria-hidden="true" tabindex="-1"></a><span class="re">END</span><span class="co">;</span></span>
+<span id="cb111-6"><a href="#cb111-6" aria-hidden="true" tabindex="-1"></a><span class="co">*/</span></span>
+<span id="cb111-7"><a href="#cb111-7" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb111-8"><a href="#cb111-8" aria-hidden="true" tabindex="-1"></a><span class="pp">#define _PROC_ &quot;combine&quot;</span></span>
+<span id="cb111-9"><a href="#cb111-9" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> combine<span class="op">(</span>cql_nullable_int32 x<span class="op">,</span> cql_nullable_int32 y<span class="op">,</span> cql_nullable_int32 <span class="op">*</span>_Nonnull result<span class="op">)</span> <span class="op">{</span></span>
+<span id="cb111-10"><a href="#cb111-10" aria-hidden="true" tabindex="-1"></a>  cql_contract_argument_notnull<span class="op">((</span><span class="dt">void</span> <span class="op">*)</span>result<span class="op">,</span> <span class="dv">3</span><span class="op">);</span></span>
+<span id="cb111-11"><a href="#cb111-11" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb111-12"><a href="#cb111-12" aria-hidden="true" tabindex="-1"></a>  cql_nullable_int32 _tmp_n_int_1<span class="op">;</span></span>
+<span id="cb111-13"><a href="#cb111-13" aria-hidden="true" tabindex="-1"></a>  cql_set_null<span class="op">(</span>_tmp_n_int_1<span class="op">);</span></span>
+<span id="cb111-14"><a href="#cb111-14" aria-hidden="true" tabindex="-1"></a>  cql_nullable_int32 _tmp_n_int_2<span class="op">;</span></span>
+<span id="cb111-15"><a href="#cb111-15" aria-hidden="true" tabindex="-1"></a>  cql_set_null<span class="op">(</span>_tmp_n_int_2<span class="op">);</span></span>
+<span id="cb111-16"><a href="#cb111-16" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb111-17"><a href="#cb111-17" aria-hidden="true" tabindex="-1"></a>  cql_set_null<span class="op">(*</span>result<span class="op">);</span> <span class="co">// set out arg to non-garbage</span></span>
+<span id="cb111-18"><a href="#cb111-18" aria-hidden="true" tabindex="-1"></a>  cql_set_nullable<span class="op">(</span>_tmp_n_int_1<span class="op">,</span> x<span class="op">.</span>is_null<span class="op">,</span> <span class="dv">5</span> <span class="op">*</span> x<span class="op">.</span>value<span class="op">);</span></span>
+<span id="cb111-19"><a href="#cb111-19" aria-hidden="true" tabindex="-1"></a>  cql_set_nullable<span class="op">(</span>_tmp_n_int_2<span class="op">,</span> y<span class="op">.</span>is_null<span class="op">,</span> <span class="dv">3</span> <span class="op">*</span> y<span class="op">.</span>value<span class="op">);</span></span>
+<span id="cb111-20"><a href="#cb111-20" aria-hidden="true" tabindex="-1"></a>  cql_combine_nullables<span class="op">(*</span>result<span class="op">,</span> _tmp_n_int_1<span class="op">.</span>is_null<span class="op">,</span> _tmp_n_int_2<span class="op">.</span>is_null<span class="op">,</span> _tmp_n_int_1<span class="op">.</span>value <span class="op">+</span> _tmp_n_int_2<span class="op">.</span>value<span class="op">);</span></span>
+<span id="cb111-21"><a href="#cb111-21" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb111-22"><a href="#cb111-22" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span>
+<span id="cb111-23"><a href="#cb111-23" aria-hidden="true" tabindex="-1"></a><span class="pp">#undef _PROC_</span></span>
+<span id="cb111-24"><a href="#cb111-24" aria-hidden="true" tabindex="-1"></a><span class="pp">#pragma clang diagnostic pop</span></span></code></pre></div>
 <ul>
-<li><code>_tmp_n_int_1</code> holds the product of x and 5, it’s null if <code>x.is_null</code> is true</li>
-<li><code>_tmp_n_int_2</code> holds the product of y and 3, it’s null if <code>y.is_null</code> is true</li>
-<li><code>*result</code> holds the answer, it’s null if either of <code>_tmp_n_int_1.is_null</code>, <code>_tmp_n_int_2.is_null</code> is true
+<li><code>_tmp_n_int_1</code> : holds the product of x and 5, it’s null if <code>x.is_null</code> is true</li>
+<li><code>_tmp_n_int_2</code> : holds the product of y and 3, it’s null if <code>y.is_null</code> is true</li>
+<li><code>*result</code> : holds the answer, it’s null if either of <code>_tmp_n_int_1.is_null</code>, <code>_tmp_n_int_2.is_null</code> is true
 <ul>
 <li>otherwise it’s <code>_tmp_n_int_1.value + _tmp_n_int_2.value</code></li>
 </ul></li>
@@ -2424,75 +2476,95 @@ static void cg_std_dml_exec_stmt(ast_node *ast) {
 <p>So, in general, we need to emit arbitarily many statements in the course of evaluating even simple looking expressions and we need good mechanisms to manage that. This is what we’ll talk about in the coming sections.</p>
 <h4 id="managing-scratch-variables">Managing Scratch Variables</h4>
 <p>The function that actually assigns scratch variables is <code>cg_scratch_var</code></p>
-<div class="sourceCode" id="cb111"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb111-1"><a href="#cb111-1" aria-hidden="true" tabindex="-1"></a><span class="co">// The scratch variable helper uses the given sem_type and the current</span></span>
-<span id="cb111-2"><a href="#cb111-2" aria-hidden="true" tabindex="-1"></a><span class="co">// stack level to create a temporary variable name for that type at that level.</span></span>
-<span id="cb111-3"><a href="#cb111-3" aria-hidden="true" tabindex="-1"></a><span class="co">// If the variable does not already have a declaration (as determined by the masks)</span></span>
-<span id="cb111-4"><a href="#cb111-4" aria-hidden="true" tabindex="-1"></a><span class="co">// then a declaration is added to the scratch_vars section.  This is one of the root</span></span>
-<span id="cb111-5"><a href="#cb111-5" aria-hidden="true" tabindex="-1"></a><span class="co">// ways of getting an .is_null and .value back.  Note that not null variables always</span></span>
-<span id="cb111-6"><a href="#cb111-6" aria-hidden="true" tabindex="-1"></a><span class="co">// have a .is_null of &quot;0&quot; which becomes important when deciding how to assign</span></span>
-<span id="cb111-7"><a href="#cb111-7" aria-hidden="true" tabindex="-1"></a><span class="co">// one result to another.  Everything stays uniform.</span></span>
-<span id="cb111-8"><a href="#cb111-8" aria-hidden="true" tabindex="-1"></a><span class="dt">static</span> <span class="dt">void</span> cg_scratch_var<span class="op">(</span>ast_node <span class="op">*</span>ast<span class="op">,</span> sem_t sem_type<span class="op">,</span> charbuf <span class="op">*</span>var<span class="op">,</span> charbuf <span class="op">*</span>is_null<span class="op">,</span> charbuf <span class="op">*</span>value<span class="op">)</span></span></code></pre></div>
-<p>The signature is a bit unexpected so we’ll go over this, some of this will make more sense as we learn about expressions generally but this is as good an introduction as any.</p>
+<div class="sourceCode" id="cb112"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb112-1"><a href="#cb112-1" aria-hidden="true" tabindex="-1"></a><span class="co">// The scratch variable helper uses the given sem_type and the current</span></span>
+<span id="cb112-2"><a href="#cb112-2" aria-hidden="true" tabindex="-1"></a><span class="co">// stack level to create a temporary variable name for that type at that level.</span></span>
+<span id="cb112-3"><a href="#cb112-3" aria-hidden="true" tabindex="-1"></a><span class="co">// If the variable does not already have a declaration (as determined by the masks)</span></span>
+<span id="cb112-4"><a href="#cb112-4" aria-hidden="true" tabindex="-1"></a><span class="co">// then a declaration is added to the scratch_vars section.  This is one of the root</span></span>
+<span id="cb112-5"><a href="#cb112-5" aria-hidden="true" tabindex="-1"></a><span class="co">// ways of getting an .is_null and .value back.  Note that not null variables always</span></span>
+<span id="cb112-6"><a href="#cb112-6" aria-hidden="true" tabindex="-1"></a><span class="co">// have a .is_null of &quot;0&quot; which becomes important when deciding how to assign</span></span>
+<span id="cb112-7"><a href="#cb112-7" aria-hidden="true" tabindex="-1"></a><span class="co">// one result to another.  Everything stays uniform.</span></span>
+<span id="cb112-8"><a href="#cb112-8" aria-hidden="true" tabindex="-1"></a><span class="dt">static</span> <span class="dt">void</span> cg_scratch_var<span class="op">(</span>ast_node <span class="op">*</span>ast<span class="op">,</span> sem_t sem_type<span class="op">,</span> charbuf <span class="op">*</span>var<span class="op">,</span> charbuf <span class="op">*</span>is_null<span class="op">,</span> charbuf <span class="op">*</span>value<span class="op">)</span></span></code></pre></div>
+<p>The signature is a bit unexpected so we’ll go over it, some of below will make more sense as we learn about expressions generally, but this is as good an introduction as any.</p>
 <ul>
-<li><code>ast</code> holds a reference to a variable we want to assign to, this is normally <code>NULL</code> for scratch variables, it’s not null for the <code>RESULT</code> macros which we’ll study later, so for now ignore this</li>
-<li><code>sem_type</code> holds the type of the variable we need, it must be a unitary type, optionally with <code>SEM_TYPE_NOTNULL</code> set</li>
-<li><code>var</code> is a character buffer that will get the name of the variable</li>
-<li><code>is_null</code> is a character buffer that will get the <code>is_null</code> expression for this variable (more below)</li>
-<li><code>value</code> is a character buffer that will get the <code>value</code> expression for this variable (more below)</li>
+<li><code>ast</code> : holds a reference to a variable we want to assign to
+<ul>
+<li>this argument is normally <code>NULL</code> for scratch variables</li>
+<li><code>ast</code> is not null for the <code>RESULT</code> macros which we’ll study later</li>
+<li>for now, we can basically ignore this argument</li>
+</ul></li>
+<li><code>sem_type</code> : holds the type of the variable we need
+<ul>
+<li>it must be a unitary type, optionally with <code>SEM_TYPE_NOTNULL</code> set</li>
+</ul></li>
+<li><code>var</code> : a character buffer that will get the name of the variable</li>
+<li><code>is_null</code> : a character buffer that will get the <code>is_null</code> expression for this variable (more below)</li>
+<li><code>value</code> : a character buffer that will get the <code>value</code> expression for this variable (more below)</li>
 </ul>
 <p>And this is a good time to talk about <code>is_null</code> and <code>value</code> because they will be everywhere.</p>
-<p>Every expression evaluation in the C code generator has two essential results, the text that corresponds to the current value so far (e.g. "(1+2)*3“) and the text for the current expression that will tell you if the result is null, this could be as simple as”0" for a expression that is known to be not null. So let’s make this a little more concrete:</p>
-<p>Suppose you ask for a scratch not null integer we get results like this:</p>
+<p>The codegen for expressions in the C code generator produces two results: * the text that corresponds to the current value so far (e.g. “(1+2)<em>3"), and, </em> the text that will tell you if the current value is null * this could be as simple as”0" for an expression that is known to be not null</p>
+<p>Let’s make this a little more concrete:</p>
+<p>Suppose we ask for a scratch “not null integer”, we get results like this:</p>
 <ul>
 <li><code>var</code>: <code>"_tmp_n_int_1"</code></li>
 <li><code>is_null</code>: <code>"0"</code></li>
 <li><code>value</code>: <code>"_tmp_n_int_1"</code></li>
 </ul>
-<p>Meaning: if you want the value, use the text "_tmp_n_int_1" if you want to know if the variable is null, use the text “0” Note: many parts of <code>cg_c.c</code> special case an <code>is_null</code> value of <code>"0"</code> to make better code because such a thing is known to be not null at compile time.</p>
-<p>Now let’s suppose you ask for a scratch nullable integer, we get results like this:</p>
+<p>Meaning: if we want the value, use the text <code>"_tmp_n_int_1"</code> if we want to know if the variable is null, we use the text <code>"0"</code></p>
+<p>Note: many parts of <code>cg_c.c</code> special case an <code>is_null</code> value of <code>"0"</code> to make better code because such a thing is known to be not null at compile time.</p>
+<p>Now let’s suppose we ask for a scratch nullable integer, we get results like this:</p>
 <ul>
 <li><code>var</code>: <code>"_tmp_int_1"</code></li>
 <li><code>is_null</code>: <code>"_tmp_int_1.is_null"</code></li>
 <li><code>value</code>: <code>"_tmp_int_1.value"</code></li>
 </ul>
-<p>So again, you have exactly the text you need to test for null and the test you need to get the value.</p>
+<p>So again, we have exactly the text we need to test for null, and the test we need to get the value.</p>
 <p>Additional notes:</p>
 <ul>
 <li>scratch variables can be re-used, they are on a “stack”</li>
 <li>a bitmask is used to track which scratch variables have aleady had a declaration emitted, so they are only declared once</li>
-<li>the variable name is based on the current value of the <code>stack_level</code> variable which is increased in a push/pop fashion as temporaries come in and out of scope</li>
+<li>the variable name is based on the current value of the <code>stack_level</code> variable which is increased in a push/pop fashion as temporaries come in and out of scope
+<ul>
 <li>this strategy isn’t perfect, but the C compiler can consolidate locals even if the CQL codegen is not perfect so it ends up being not so bad</li>
-<li>importantly there is one stacklevel variable for all temporaries not one stacklevel for every type of temporary, this seemed like a reasonable simplification</li>
+<li>importantly, there is one <code>stack_level</code> variable for all temporaries not one <code>stack_level</code> for every type of temporary, this seemed like a reasonable simplification</li>
+</ul></li>
 </ul>
 <h4 id="allocating-scratch-variables">Allocating Scratch Variables</h4>
-<p>The most common reason for a scratch variable is that a temporary is needed for some part of the computation. The most common reason for a temporary variable is to hold an intermediate result of a computation involving nullable arithmetic.</p>
-<p>These temporaries are created with <code>CG_PUSH_TEMP</code> which simply creates the three <code>charbuf</code> variables you need and then asks for a scratch variable of the type you need. The variables follow a simple naming convention. The stack level is increased.</p>
-<div class="sourceCode" id="cb112"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb112-1"><a href="#cb112-1" aria-hidden="true" tabindex="-1"></a><span class="co">// Create buffers for a temporary variable.  Use cg_scratch_var to fill in the buffers</span></span>
-<span id="cb112-2"><a href="#cb112-2" aria-hidden="true" tabindex="-1"></a><span class="co">// with the text needed to refer to the variable.  cg_scratch_var picks the name</span></span>
-<span id="cb112-3"><a href="#cb112-3" aria-hidden="true" tabindex="-1"></a><span class="co">// based on stack level-and type.</span></span>
-<span id="cb112-4"><a href="#cb112-4" aria-hidden="true" tabindex="-1"></a><span class="pp">#define CG_PUSH_TEMP(name, sem_type) \</span></span>
-<span id="cb112-5"><a href="#cb112-5" aria-hidden="true" tabindex="-1"></a><span class="pp">CHARBUF_OPEN(name); \</span></span>
-<span id="cb112-6"><a href="#cb112-6" aria-hidden="true" tabindex="-1"></a><span class="pp">CHARBUF_OPEN(name##_is_null); \</span></span>
-<span id="cb112-7"><a href="#cb112-7" aria-hidden="true" tabindex="-1"></a><span class="pp">CHARBUF_OPEN(name##_value); \</span></span>
-<span id="cb112-8"><a href="#cb112-8" aria-hidden="true" tabindex="-1"></a><span class="pp">cg_scratch_var(NULL, sem_type, &amp;name, &amp;name##_is_null, &amp;name##_value); \</span></span>
-<span id="cb112-9"><a href="#cb112-9" aria-hidden="true" tabindex="-1"></a><span class="pp">stack_level++;</span></span></code></pre></div>
-<p>Symetrically, <code>CG_POP_TEMP</code> releases the charbufs and restores the stack level. As with the other macros, these are designed to make it impossible to forget to free your buffers or get the stack wrong. In fact, the stack is checked at strategic places to ensure its back to baseline. You can always just snapshot <code>stacklevel</code>, do some work that should be clean, and then add an <code>Invariant</code> that <code>stacklevel</code> is back to where it was.</p>
-<div class="sourceCode" id="cb113"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb113-1"><a href="#cb113-1" aria-hidden="true" tabindex="-1"></a><span class="co">// Release the buffers for the temporary, restore the stack level.</span></span>
-<span id="cb113-2"><a href="#cb113-2" aria-hidden="true" tabindex="-1"></a><span class="pp">#define CG_POP_TEMP(name) \</span></span>
-<span id="cb113-3"><a href="#cb113-3" aria-hidden="true" tabindex="-1"></a><span class="pp">CHARBUF_CLOSE(name##_value); \</span></span>
-<span id="cb113-4"><a href="#cb113-4" aria-hidden="true" tabindex="-1"></a><span class="pp">CHARBUF_CLOSE(name##_is_null); \</span></span>
-<span id="cb113-5"><a href="#cb113-5" aria-hidden="true" tabindex="-1"></a><span class="pp">CHARBUF_CLOSE(name); \</span></span>
-<span id="cb113-6"><a href="#cb113-6" aria-hidden="true" tabindex="-1"></a><span class="pp">stack_level--;</span></span></code></pre></div>
+<p>The most common reason to create a “scratch” variable is that a temporary variable is needed for some part of the computation. The most common reason for a temporary variable is to hold an intermediate result of a computation involving nullable arithmetic.</p>
+<p>These temporaries are created with <code>CG_PUSH_TEMP</code> which simply creates the three <code>charbuf</code> variables needed and then asks for a scratch variable of the required type. The variables follow a simple naming convention. The stack level is increased after each temporary is allocated.</p>
+<div class="sourceCode" id="cb113"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb113-1"><a href="#cb113-1" aria-hidden="true" tabindex="-1"></a><span class="co">// Create buffers for a temporary variable.  Use cg_scratch_var to fill in the buffers</span></span>
+<span id="cb113-2"><a href="#cb113-2" aria-hidden="true" tabindex="-1"></a><span class="co">// with the text needed to refer to the variable.  cg_scratch_var picks the name</span></span>
+<span id="cb113-3"><a href="#cb113-3" aria-hidden="true" tabindex="-1"></a><span class="co">// based on stack level-and type.</span></span>
+<span id="cb113-4"><a href="#cb113-4" aria-hidden="true" tabindex="-1"></a><span class="pp">#define CG_PUSH_TEMP(name, sem_type) \</span></span>
+<span id="cb113-5"><a href="#cb113-5" aria-hidden="true" tabindex="-1"></a><span class="pp">  CHARBUF_OPEN(name); \</span></span>
+<span id="cb113-6"><a href="#cb113-6" aria-hidden="true" tabindex="-1"></a><span class="pp">  CHARBUF_OPEN(name##_is_null); \</span></span>
+<span id="cb113-7"><a href="#cb113-7" aria-hidden="true" tabindex="-1"></a><span class="pp">  CHARBUF_OPEN(name##_value); \</span></span>
+<span id="cb113-8"><a href="#cb113-8" aria-hidden="true" tabindex="-1"></a><span class="pp">  cg_scratch_var(NULL, sem_type, &amp;name, &amp;name##_is_null, &amp;name##_value); \</span></span>
+<span id="cb113-9"><a href="#cb113-9" aria-hidden="true" tabindex="-1"></a><span class="pp">  stack_level++;</span></span></code></pre></div>
+<p>Symmetrically, <code>CG_POP_TEMP</code> closes the <code>charbuf</code> variables and restores the stack level.</p>
+<div class="sourceCode" id="cb114"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb114-1"><a href="#cb114-1" aria-hidden="true" tabindex="-1"></a><span class="co">// Release the buffers for the temporary, restore the stack level.</span></span>
+<span id="cb114-2"><a href="#cb114-2" aria-hidden="true" tabindex="-1"></a><span class="pp">#define CG_POP_TEMP(name) \</span></span>
+<span id="cb114-3"><a href="#cb114-3" aria-hidden="true" tabindex="-1"></a><span class="pp">  CHARBUF_CLOSE(name##_value); \</span></span>
+<span id="cb114-4"><a href="#cb114-4" aria-hidden="true" tabindex="-1"></a><span class="pp">  CHARBUF_CLOSE(name##_is_null); \</span></span>
+<span id="cb114-5"><a href="#cb114-5" aria-hidden="true" tabindex="-1"></a><span class="pp">  CHARBUF_CLOSE(name); \</span></span>
+<span id="cb114-6"><a href="#cb114-6" aria-hidden="true" tabindex="-1"></a><span class="pp">  stack_level--;</span></span></code></pre></div>
+<p>As with the other <code>PUSH/POP</code> <code>OPEN/CLOSE</code> macro types, these macros are designed to make it impossible to forget to free the buffers, or to get the stack level wrong. The stack level can be (and is) checked at strategic places to ensure it’s back to baseline – this is easy because the code can always just snapshot <code>stack_level</code>, do some work that should be clean, and then check that <code>stack_level</code> is back to where it’s supposed to be with an <code>Invariant</code>.</p>
 <h4 id="recursing-sub-expressions">Recursing Sub-expressions</h4>
 <p>Now that we understand that we can create scratch variables as needed, it’s time to take a look at the typical evaluation patterns and how the evaluation works within that pattern. This is everywhere in <code>cg_c.c</code>.</p>
 <p>So let’s look at an actual evaluator, the simplest of them all, this one does code generation for the <code>NULL</code> literal.</p>
-<div class="sourceCode" id="cb114"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb114-1"><a href="#cb114-1" aria-hidden="true" tabindex="-1"></a><span class="dt">static</span> <span class="dt">void</span> cg_expr_null<span class="op">(</span>ast_node <span class="op">*</span>expr<span class="op">,</span> CSTR op<span class="op">,</span> charbuf <span class="op">*</span>is_null<span class="op">,</span> charbuf <span class="op">*</span>value<span class="op">,</span> <span class="dt">int32_t</span> pri<span class="op">,</span> <span class="dt">int32_t</span> pri_new<span class="op">)</span> <span class="op">{</span></span>
-<span id="cb114-2"><a href="#cb114-2" aria-hidden="true" tabindex="-1"></a>  Contract<span class="op">(</span>is_ast_null<span class="op">(</span>expr<span class="op">));</span></span>
-<span id="cb114-3"><a href="#cb114-3" aria-hidden="true" tabindex="-1"></a>  <span class="co">// null literal</span></span>
-<span id="cb114-4"><a href="#cb114-4" aria-hidden="true" tabindex="-1"></a>  bprintf<span class="op">(</span>value<span class="op">,</span> <span class="st">&quot;NULL&quot;</span><span class="op">);</span></span>
-<span id="cb114-5"><a href="#cb114-5" aria-hidden="true" tabindex="-1"></a>  bprintf<span class="op">(</span>is_null<span class="op">,</span> <span class="st">&quot;1&quot;</span><span class="op">);</span></span>
-<span id="cb114-6"><a href="#cb114-6" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span></code></pre></div>
-<p>Now this may be looking familiar: the signature of the code generator is something very much like the signature of the the <code>gen_</code> functions in the echoing code. That’s really because in some sense the echoing code is like a very simple code generator itself.</p>
+<div class="sourceCode" id="cb115"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb115-1"><a href="#cb115-1" aria-hidden="true" tabindex="-1"></a><span class="dt">static</span> <span class="dt">void</span> cg_expr_null<span class="op">(</span></span>
+<span id="cb115-2"><a href="#cb115-2" aria-hidden="true" tabindex="-1"></a>  ast_node <span class="op">*</span>expr<span class="op">,</span></span>
+<span id="cb115-3"><a href="#cb115-3" aria-hidden="true" tabindex="-1"></a>  CSTR op<span class="op">,</span></span>
+<span id="cb115-4"><a href="#cb115-4" aria-hidden="true" tabindex="-1"></a>  charbuf <span class="op">*</span>is_null<span class="op">,</span></span>
+<span id="cb115-5"><a href="#cb115-5" aria-hidden="true" tabindex="-1"></a>  charbuf <span class="op">*</span>value<span class="op">,</span></span>
+<span id="cb115-6"><a href="#cb115-6" aria-hidden="true" tabindex="-1"></a>  <span class="dt">int32_t</span> pri<span class="op">,</span></span>
+<span id="cb115-7"><a href="#cb115-7" aria-hidden="true" tabindex="-1"></a>  <span class="dt">int32_t</span> pri_new<span class="op">)</span></span>
+<span id="cb115-8"><a href="#cb115-8" aria-hidden="true" tabindex="-1"></a><span class="op">{</span></span>
+<span id="cb115-9"><a href="#cb115-9" aria-hidden="true" tabindex="-1"></a>  Contract<span class="op">(</span>is_ast_null<span class="op">(</span>expr<span class="op">));</span></span>
+<span id="cb115-10"><a href="#cb115-10" aria-hidden="true" tabindex="-1"></a>  <span class="co">// null literal</span></span>
+<span id="cb115-11"><a href="#cb115-11" aria-hidden="true" tabindex="-1"></a>  bprintf<span class="op">(</span>value<span class="op">,</span> <span class="st">&quot;NULL&quot;</span><span class="op">);</span></span>
+<span id="cb115-12"><a href="#cb115-12" aria-hidden="true" tabindex="-1"></a>  bprintf<span class="op">(</span>is_null<span class="op">,</span> <span class="st">&quot;1&quot;</span><span class="op">);</span></span>
+<span id="cb115-13"><a href="#cb115-13" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span></code></pre></div>
+<p>Now this may be looking familiar: the signature of the code generator is something very much like the signature of the the <code>gen_</code> functions in the echoing code. That’s really because in some sense the echoing code is a very simple code generator itself.</p>
 <ul>
 <li><code>expr</code> : the AST we are generating code for</li>
 <li><code>op</code> : the relevant operator if any (operators share code)</li>
@@ -2502,217 +2574,225 @@ static void cg_std_dml_exec_stmt(ast_node *ast) {
 <li><code>pri_new</code> : the binding strength of this node</li>
 </ul>
 <p>This particular generator is going to produce <code>"NULL"</code> for the <code>value</code> and <code>"1"</code> for the <code>is_null</code> expression.</p>
-<p><code>is_null</code> and <code>value</code> are the chief outputs, and the caller will use these to create its own expression results with recursive logic. But the expression logic can also write into the statement stream, and as we’ll see, it does.</p>
+<p><code>is_null</code> and <code>value</code> are the chief outputs, and the caller will use these to create its own expression results with recursive logic. But the expression logic can also write into the statement stream, the cleanup stream, even into the header file stream, and as we’ll see, it does.</p>
 <p><code>pri</code> and <code>pri_new</code> work exactly like they did in the echoing code (see <a href="https://cgsql.dev/cql-guide/int01">Part 1</a>), they are used to allow the code generator to decide if it needs to emit parentheses. But recall that the binding strengths now will be the C binding strengths NOT the SQL binding strengths (discussed above).</p>
 <p>Let’s look at one of the simplest operators: the <code>IS NULL</code> operator handled by <code>cg_expr_is_null</code></p>
-<div class="sourceCode" id="cb115"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb115-1"><a href="#cb115-1" aria-hidden="true" tabindex="-1"></a><span class="co">// The code-gen for is_null is one of the easiest.  The recursive call</span></span>
-<span id="cb115-2"><a href="#cb115-2" aria-hidden="true" tabindex="-1"></a><span class="co">// produces is_null as one of the outputs.  Use that.  Our is_null result</span></span>
-<span id="cb115-3"><a href="#cb115-3" aria-hidden="true" tabindex="-1"></a><span class="co">// is always zero because IS NULL is never, itself, null.</span></span>
-<span id="cb115-4"><a href="#cb115-4" aria-hidden="true" tabindex="-1"></a><span class="dt">static</span> <span class="dt">void</span> cg_expr_is_null<span class="op">(</span>ast_node <span class="op">*</span>expr<span class="op">,</span> charbuf <span class="op">*</span>is_null<span class="op">,</span> charbuf <span class="op">*</span>value<span class="op">)</span> <span class="op">{</span></span>
-<span id="cb115-5"><a href="#cb115-5" aria-hidden="true" tabindex="-1"></a>  sem_t sem_type_expr <span class="op">=</span> expr<span class="op">-&gt;</span>sem<span class="op">-&gt;</span>sem_type<span class="op">;</span></span>
-<span id="cb115-6"><a href="#cb115-6" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb115-7"><a href="#cb115-7" aria-hidden="true" tabindex="-1"></a>  <span class="co">// expr IS NULL</span></span>
-<span id="cb115-8"><a href="#cb115-8" aria-hidden="true" tabindex="-1"></a>  bprintf<span class="op">(</span>is_null<span class="op">,</span> <span class="st">&quot;0&quot;</span><span class="op">);</span> <span class="co">// the result of is null is never null</span></span>
-<span id="cb115-9"><a href="#cb115-9" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb115-10"><a href="#cb115-10" aria-hidden="true" tabindex="-1"></a>  <span class="co">// The fact that this is not constant not null for not null reference types reflects</span></span>
-<span id="cb115-11"><a href="#cb115-11" aria-hidden="true" tabindex="-1"></a>  <span class="co">// the weird state of affairs with uninitualized reference variables which</span></span>
-<span id="cb115-12"><a href="#cb115-12" aria-hidden="true" tabindex="-1"></a>  <span class="co">// must be null even if they are typed not null.</span></span>
-<span id="cb115-13"><a href="#cb115-13" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb115-14"><a href="#cb115-14" aria-hidden="true" tabindex="-1"></a>  <span class="cf">if</span> <span class="op">(</span>is_not_nullable<span class="op">(</span>sem_type_expr<span class="op">)</span> <span class="op">&amp;&amp;</span> <span class="op">!</span>is_ref_type<span class="op">(</span>sem_type_expr<span class="op">))</span> <span class="op">{</span></span>
-<span id="cb115-15"><a href="#cb115-15" aria-hidden="true" tabindex="-1"></a>    <span class="co">// Note, sql has no side-effects so we can fold this away.</span></span>
-<span id="cb115-16"><a href="#cb115-16" aria-hidden="true" tabindex="-1"></a>    bprintf<span class="op">(</span>value<span class="op">,</span> <span class="st">&quot;0&quot;</span><span class="op">);</span></span>
-<span id="cb115-17"><a href="#cb115-17" aria-hidden="true" tabindex="-1"></a>  <span class="op">}</span></span>
-<span id="cb115-18"><a href="#cb115-18" aria-hidden="true" tabindex="-1"></a>  <span class="cf">else</span> <span class="op">{</span></span>
-<span id="cb115-19"><a href="#cb115-19" aria-hidden="true" tabindex="-1"></a>    CG_PUSH_EVAL<span class="op">(</span>expr<span class="op">,</span> C_EXPR_PRI_ROOT<span class="op">);</span></span>
-<span id="cb115-20"><a href="#cb115-20" aria-hidden="true" tabindex="-1"></a>    bprintf<span class="op">(</span>value<span class="op">,</span> <span class="st">&quot;%s&quot;</span><span class="op">,</span> expr_is_null<span class="op">.</span>ptr<span class="op">);</span></span>
-<span id="cb115-21"><a href="#cb115-21" aria-hidden="true" tabindex="-1"></a>    CG_POP_EVAL<span class="op">(</span>expr<span class="op">);</span></span>
-<span id="cb115-22"><a href="#cb115-22" aria-hidden="true" tabindex="-1"></a>  <span class="op">}</span></span>
-<span id="cb115-23"><a href="#cb115-23" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span></code></pre></div>
-<p>So walking through this: * the result of <code>IS NULL</code> is never null, so we can immediately put “0” into the <code>is_null</code> buffer * if the operand is a not-null numeric type then the result of <code>IS NULL</code> is <code>0</code> * if the operand might actually be null then * use <code>CG_PUSH_EVAL</code> to recursively do codegen for it * copy its <code>expr_is_null</code> text into our <code>value</code> text</p>
-<p>Note: the code reveals one of the big CQL secrets that not null reference variables can be null… C has the same issue with <code>_Nonnull</code> globals.</p>
+<p>Note: this code has a simpler signature because it’s actually part of codegen for <code>cg_expr_is</code> which has the general contract.</p>
+<div class="sourceCode" id="cb116"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb116-1"><a href="#cb116-1" aria-hidden="true" tabindex="-1"></a><span class="co">// The code-gen for is_null is one of the easiest.  The recursive call</span></span>
+<span id="cb116-2"><a href="#cb116-2" aria-hidden="true" tabindex="-1"></a><span class="co">// produces is_null as one of the outputs.  Use that.  Our is_null result</span></span>
+<span id="cb116-3"><a href="#cb116-3" aria-hidden="true" tabindex="-1"></a><span class="co">// is always zero because IS NULL is never, itself, null.</span></span>
+<span id="cb116-4"><a href="#cb116-4" aria-hidden="true" tabindex="-1"></a><span class="dt">static</span> <span class="dt">void</span> cg_expr_is_null<span class="op">(</span>ast_node <span class="op">*</span>expr<span class="op">,</span> charbuf <span class="op">*</span>is_null<span class="op">,</span> charbuf <span class="op">*</span>value<span class="op">)</span> <span class="op">{</span></span>
+<span id="cb116-5"><a href="#cb116-5" aria-hidden="true" tabindex="-1"></a>  sem_t sem_type_expr <span class="op">=</span> expr<span class="op">-&gt;</span>sem<span class="op">-&gt;</span>sem_type<span class="op">;</span></span>
+<span id="cb116-6"><a href="#cb116-6" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb116-7"><a href="#cb116-7" aria-hidden="true" tabindex="-1"></a>  <span class="co">// expr IS NULL</span></span>
+<span id="cb116-8"><a href="#cb116-8" aria-hidden="true" tabindex="-1"></a>  bprintf<span class="op">(</span>is_null<span class="op">,</span> <span class="st">&quot;0&quot;</span><span class="op">);</span> <span class="co">// the result of is null is never null</span></span>
+<span id="cb116-9"><a href="#cb116-9" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb116-10"><a href="#cb116-10" aria-hidden="true" tabindex="-1"></a>  <span class="co">// The fact that this is not constant not null for not null reference types reflects</span></span>
+<span id="cb116-11"><a href="#cb116-11" aria-hidden="true" tabindex="-1"></a>  <span class="co">// the weird state of affairs with uninitualized reference variables which</span></span>
+<span id="cb116-12"><a href="#cb116-12" aria-hidden="true" tabindex="-1"></a>  <span class="co">// must be null even if they are typed not null.</span></span>
+<span id="cb116-13"><a href="#cb116-13" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb116-14"><a href="#cb116-14" aria-hidden="true" tabindex="-1"></a>  <span class="cf">if</span> <span class="op">(</span>is_not_nullable<span class="op">(</span>sem_type_expr<span class="op">)</span> <span class="op">&amp;&amp;</span> <span class="op">!</span>is_ref_type<span class="op">(</span>sem_type_expr<span class="op">))</span> <span class="op">{</span></span>
+<span id="cb116-15"><a href="#cb116-15" aria-hidden="true" tabindex="-1"></a>    <span class="co">// Note, sql has no side-effects so we can fold this away.</span></span>
+<span id="cb116-16"><a href="#cb116-16" aria-hidden="true" tabindex="-1"></a>    bprintf<span class="op">(</span>value<span class="op">,</span> <span class="st">&quot;0&quot;</span><span class="op">);</span></span>
+<span id="cb116-17"><a href="#cb116-17" aria-hidden="true" tabindex="-1"></a>  <span class="op">}</span></span>
+<span id="cb116-18"><a href="#cb116-18" aria-hidden="true" tabindex="-1"></a>  <span class="cf">else</span> <span class="op">{</span></span>
+<span id="cb116-19"><a href="#cb116-19" aria-hidden="true" tabindex="-1"></a>    CG_PUSH_EVAL<span class="op">(</span>expr<span class="op">,</span> C_EXPR_PRI_ROOT<span class="op">);</span></span>
+<span id="cb116-20"><a href="#cb116-20" aria-hidden="true" tabindex="-1"></a>    bprintf<span class="op">(</span>value<span class="op">,</span> <span class="st">&quot;%s&quot;</span><span class="op">,</span> expr_is_null<span class="op">.</span>ptr<span class="op">);</span></span>
+<span id="cb116-21"><a href="#cb116-21" aria-hidden="true" tabindex="-1"></a>    CG_POP_EVAL<span class="op">(</span>expr<span class="op">);</span></span>
+<span id="cb116-22"><a href="#cb116-22" aria-hidden="true" tabindex="-1"></a>  <span class="op">}</span></span>
+<span id="cb116-23"><a href="#cb116-23" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span></code></pre></div>
+<p>So walking through the above: * the result of <code>IS NULL</code> is never null, so we can immediately put “0” into the <code>is_null</code> buffer * if the operand is a not-null numeric type then the result of <code>IS NULL</code> is <code>0</code> * if the operand might actually be null then * use <code>CG_PUSH_EVAL</code> to recursively do codegen for it * copy its <code>expr_is_null</code> text into our <code>value</code> text</p>
+<p>Note: the code reveals one of the big CQL secrets – that not null reference variables can be null… C has the same issue with <code>_Nonnull</code> globals.</p>
 <p>Now let’s look at those helper macros, they are pretty simple:</p>
-<div class="sourceCode" id="cb116"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb116-1"><a href="#cb116-1" aria-hidden="true" tabindex="-1"></a><span class="co">// Make a temporary buffer for the evaluation results using the canonical naming convention</span></span>
-<span id="cb116-2"><a href="#cb116-2" aria-hidden="true" tabindex="-1"></a><span class="co">// burn the stack slot so that any type and numbered temporary that was needed</span></span>
-<span id="cb116-3"><a href="#cb116-3" aria-hidden="true" tabindex="-1"></a><span class="co">// won&#39;t be re-used until this scope is over.</span></span>
-<span id="cb116-4"><a href="#cb116-4" aria-hidden="true" tabindex="-1"></a><span class="pp">#define CG_PUSH_EVAL(expr, pri) \</span></span>
-<span id="cb116-5"><a href="#cb116-5" aria-hidden="true" tabindex="-1"></a><span class="pp">CHARBUF_OPEN(expr##_is_null); \</span></span>
-<span id="cb116-6"><a href="#cb116-6" aria-hidden="true" tabindex="-1"></a><span class="pp">CHARBUF_OPEN(expr##_value); \</span></span>
-<span id="cb116-7"><a href="#cb116-7" aria-hidden="true" tabindex="-1"></a><span class="pp">cg_expr(expr, &amp;expr##_is_null, &amp;expr##_value, pri); \</span></span>
-<span id="cb116-8"><a href="#cb116-8" aria-hidden="true" tabindex="-1"></a><span class="pp">stack_level++;</span></span></code></pre></div>
-<p>The push macro simply creates buffers to hold the <code>is_null</code> and <code>value</code> results, then it calls <code>cg_expr</code> to dispatch the indicated expression. The <code>pri</code> value provided to this macro represents the binding strength that the callee should assume its parent has. Usually this is your <code>pri_new</code> value but often you can use <code>C_EXPR_PRI_ROOT</code> if you know that, because of your current context, the callee will never need parentheses.</p>
-<p>How do we know this here? It seems like the operand of <code>IS NULL</code> could be anything surely it might need parentheses? Let’s consider:</p>
+<div class="sourceCode" id="cb117"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb117-1"><a href="#cb117-1" aria-hidden="true" tabindex="-1"></a><span class="co">// Make a temporary buffer for the evaluation results using the canonical naming convention</span></span>
+<span id="cb117-2"><a href="#cb117-2" aria-hidden="true" tabindex="-1"></a><span class="co">// burn the stack slot so that any type and numbered temporary that was needed</span></span>
+<span id="cb117-3"><a href="#cb117-3" aria-hidden="true" tabindex="-1"></a><span class="co">// won&#39;t be re-used until this scope is over.</span></span>
+<span id="cb117-4"><a href="#cb117-4" aria-hidden="true" tabindex="-1"></a><span class="pp">#define CG_PUSH_EVAL(expr, pri) \</span></span>
+<span id="cb117-5"><a href="#cb117-5" aria-hidden="true" tabindex="-1"></a><span class="pp">  CHARBUF_OPEN(expr##_is_null); \</span></span>
+<span id="cb117-6"><a href="#cb117-6" aria-hidden="true" tabindex="-1"></a><span class="pp">  CHARBUF_OPEN(expr##_value); \</span></span>
+<span id="cb117-7"><a href="#cb117-7" aria-hidden="true" tabindex="-1"></a><span class="pp">  cg_expr(expr, &amp;expr##_is_null, &amp;expr##_value, pri); \</span></span>
+<span id="cb117-8"><a href="#cb117-8" aria-hidden="true" tabindex="-1"></a><span class="pp">  stack_level++;</span></span></code></pre></div>
+<p>The push macro simply creates buffers to hold the <code>is_null</code> and <code>value</code> results, then it calls <code>cg_expr</code> to dispatch the indicated expression. The <code>pri</code> value provided to this macro represents the binding strength that the callee should assume its parent has. Usually this is the <code>pri_new</code> of the caller. but often <code>C_EXPR_PRI_ROOT</code> can be used if the current context implies that the callee will never need parentheses.</p>
+<p>How do we know that parens are not needed here? It seems like the operand of <code>IS NULL</code> could be anything, surely it might need parentheses? Let’s consider:</p>
 <ul>
-<li>if the operand is of not null numeric type then we aren’t even going to evaluate it, we’re on the easy “no it’s not null” path</li>
-<li>if the operand is nullable then the only place the answer can be stored is in a scratch variable and its <code>is_null</code> expression will be exactly like <code>var.is_null</code></li>
-<li>if the operand is a reference type, there are no operators that combine reference types to get more reference types, so again the result must be in a variable, and is <code>is_null</code> expression will be like <code>!var</code></li>
+<li>if the operand is of not null numeric type then we aren’t even going to evaluate it, we’re on the easy “no it’s not null” path
+<ul>
+<li>no parens there</li>
+</ul></li>
+<li>if the operand is nullable then the only place the answer can be stored is in a scratch variable and its <code>is_null</code> expression will be exactly like <code>var.is_null</code>
+<ul>
+<li>no parens there</li>
+</ul></li>
+<li>if the operand is a reference type, there are no operators that combine reference types to get more reference types, so again the result must be in a variable, and is <code>is_null</code> expression will be like <code>!var</code>
+<ul>
+<li>no parens there</li>
+</ul></li>
 </ul>
-<p>None of these require further wrapping regardless of what is above this node in the tree because of he strength of the <code>.</code> and <code>!</code> operators.</p>
+<p>So, none of these require further wrapping regardless of what is above the <code>IS NULL</code> node in the tree because of the high strength of the <code>.</code> and <code>!</code> operators.</p>
 <p>Other cases are usually simpler, such as “no parentheses need to be added by the child node becasue it will be used as the argument to a helper function so there will always be parens hard-coded anyway”. However these things need to be carefully tested hence the huge variety of codegen tests.</p>
 <p>Note that after calling <code>cg_expr</code> the stack level was artificially increased. We’ll get to that in the next section. For now, looking at <code>POP_EVAL</code> we can see it’s very straightforward:</p>
-<div class="sourceCode" id="cb117"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb117-1"><a href="#cb117-1" aria-hidden="true" tabindex="-1"></a><span class="co">// Close the buffers used for the above.  Return the stack level to its original state.</span></span>
-<span id="cb117-2"><a href="#cb117-2" aria-hidden="true" tabindex="-1"></a><span class="co">// Numbered scratch variables are re-used as though they were a stack.</span></span>
-<span id="cb117-3"><a href="#cb117-3" aria-hidden="true" tabindex="-1"></a><span class="pp">#define CG_POP_EVAL(expr) \</span></span>
-<span id="cb117-4"><a href="#cb117-4" aria-hidden="true" tabindex="-1"></a><span class="pp">CHARBUF_CLOSE(expr##_value); \</span></span>
-<span id="cb117-5"><a href="#cb117-5" aria-hidden="true" tabindex="-1"></a><span class="pp">CHARBUF_CLOSE(expr##_is_null); \</span></span>
-<span id="cb117-6"><a href="#cb117-6" aria-hidden="true" tabindex="-1"></a><span class="pp">stack_level--;</span></span></code></pre></div>
-<p><code>CG_POP_EVAL</code> simply closes the buffers and restores the stack.</p>
+<div class="sourceCode" id="cb118"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb118-1"><a href="#cb118-1" aria-hidden="true" tabindex="-1"></a><span class="co">// Close the buffers used for the above.  Return the stack level to its original state.</span></span>
+<span id="cb118-2"><a href="#cb118-2" aria-hidden="true" tabindex="-1"></a><span class="co">// Numbered scratch variables are re-used as though they were a stack.</span></span>
+<span id="cb118-3"><a href="#cb118-3" aria-hidden="true" tabindex="-1"></a><span class="pp">#define CG_POP_EVAL(expr) \</span></span>
+<span id="cb118-4"><a href="#cb118-4" aria-hidden="true" tabindex="-1"></a><span class="pp">CHARBUF_CLOSE(expr##_value); \</span></span>
+<span id="cb118-5"><a href="#cb118-5" aria-hidden="true" tabindex="-1"></a><span class="pp">CHARBUF_CLOSE(expr##_is_null); \</span></span>
+<span id="cb118-6"><a href="#cb118-6" aria-hidden="true" tabindex="-1"></a><span class="pp">stack_level--;</span></span></code></pre></div>
+<p><code>CG_POP_EVAL</code> simply closes the buffers and restores the stack level.</p>
 <h4 id="result-variables">Result Variables</h4>
-<p>When recursion happens in the codegen, the common place that the result will be found is in a temporary variable – the generated code will use one or more statements to arrange for the correct answer to be in that variable. To do this, the codegen needs to first get the name of a suitable result variable of a suitable type. This is the “other” reason for making scratch variables.</p>
+<p>When recursion happens in the codegen, a common place that the result will be found is in a temporary variable i.e. the generated code will use one or more statements to arrange for the correct answer to be in a variable. To do this, the codegen needs to first get the name of a result variable of a suitable type. This is the “other” reason for making scratch variables.</p>
 <p>There are three macros that make this pretty simple. The first is <code>CG_RESERVE_RESULT_VAR</code></p>
-<div class="sourceCode" id="cb118"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb118-1"><a href="#cb118-1" aria-hidden="true" tabindex="-1"></a><span class="co">// Make a scratch variable to hold the final result of an evaluation.</span></span>
-<span id="cb118-2"><a href="#cb118-2" aria-hidden="true" tabindex="-1"></a><span class="co">// It may or may not be used.  It should be the first thing you put</span></span>
-<span id="cb118-3"><a href="#cb118-3" aria-hidden="true" tabindex="-1"></a><span class="co">// so that it is on the top of your stack.  This only saves the slot.</span></span>
-<span id="cb118-4"><a href="#cb118-4" aria-hidden="true" tabindex="-1"></a><span class="pp">#define CG_RESERVE_RESULT_VAR(ast, sem_type) \</span></span>
-<span id="cb118-5"><a href="#cb118-5" aria-hidden="true" tabindex="-1"></a><span class="pp">int32_t stack_level_reserved = stack_level; \</span></span>
-<span id="cb118-6"><a href="#cb118-6" aria-hidden="true" tabindex="-1"></a><span class="pp">sem_t sem_type_reserved = sem_type; \</span></span>
-<span id="cb118-7"><a href="#cb118-7" aria-hidden="true" tabindex="-1"></a><span class="pp">ast_node *ast_reserved = ast; \</span></span>
-<span id="cb118-8"><a href="#cb118-8" aria-hidden="true" tabindex="-1"></a><span class="pp">CHARBUF_OPEN(result_var); \</span></span>
-<span id="cb118-9"><a href="#cb118-9" aria-hidden="true" tabindex="-1"></a><span class="pp">CHARBUF_OPEN(result_var_is_null); \</span></span>
-<span id="cb118-10"><a href="#cb118-10" aria-hidden="true" tabindex="-1"></a><span class="pp">CHARBUF_OPEN(result_var_value); \</span></span>
-<span id="cb118-11"><a href="#cb118-11" aria-hidden="true" tabindex="-1"></a><span class="pp">stack_level++;</span></span></code></pre></div>
-<p>If this looks a lot like <code>PUSH_TEMP</code> that shouldn’t be surprising. The name of the variable and the expression parts always go into <code>charbuf</code> variables named <code>result_var</code> <code>result_var_is_null</code> and <code>result_var_value</code> but the scratch variable isn’t actually allocated! However – we burn the stack_level as though it had been allocated. What’s up with that?</p>
-<p>The name might be a clue, this macro reserves stack level slot for the result variable, it’s used if you might need a result variable, but you might not. When you want it we can artificially move the stack level back to this spot where the slot was burned, allocate the scratch variable, and then put the stack back. The <code>CG_USE_RESULT_VAR</code> macro does exactly that.</p>
-<div class="sourceCode" id="cb119"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb119-1"><a href="#cb119-1" aria-hidden="true" tabindex="-1"></a><span class="co">// If the result variable is going to be used, this writes its name</span></span>
-<span id="cb119-2"><a href="#cb119-2" aria-hidden="true" tabindex="-1"></a><span class="co">// and .value and .is_null into the is_null and value fields.</span></span>
-<span id="cb119-3"><a href="#cb119-3" aria-hidden="true" tabindex="-1"></a><span class="pp">#define CG_USE_RESULT_VAR() \</span></span>
-<span id="cb119-4"><a href="#cb119-4" aria-hidden="true" tabindex="-1"></a><span class="pp">int32_t stack_level_now = stack_level; \</span></span>
-<span id="cb119-5"><a href="#cb119-5" aria-hidden="true" tabindex="-1"></a><span class="pp">stack_level = stack_level_reserved; \</span></span>
-<span id="cb119-6"><a href="#cb119-6" aria-hidden="true" tabindex="-1"></a><span class="pp">cg_scratch_var(ast_reserved, sem_type_reserved, &amp;result_var, &amp;result_var_is_null, &amp;result_var_value); \</span></span>
-<span id="cb119-7"><a href="#cb119-7" aria-hidden="true" tabindex="-1"></a><span class="pp">stack_level = stack_level_now; \</span></span>
-<span id="cb119-8"><a href="#cb119-8" aria-hidden="true" tabindex="-1"></a><span class="pp">Invariant(result_var.used &gt; 1); \</span></span>
-<span id="cb119-9"><a href="#cb119-9" aria-hidden="true" tabindex="-1"></a><span class="pp">bprintf(is_null, &quot;%s&quot;, result_var_is_null.ptr); \</span></span>
-<span id="cb119-10"><a href="#cb119-10" aria-hidden="true" tabindex="-1"></a><span class="pp">bprintf(value, &quot;%s&quot;, result_var_value.ptr)</span></span></code></pre></div>
-<p>Once the code generator decides that it will in fact be using a result variable to represent the answer, then the <code>is_null</code> and <code>value</code> buffers can be immediately populated to whatever the values were for the result variable. That text will be correct regardless of what codegen is used to populate the variable.</p>
-<p>There is a simpler macro that reserves and uses the result variable in one step, it’s very common. The “reserve” pattern is only necessary when there are some paths that need a result variable and some that don’t.</p>
-<pre><code>// This does reserve and use in one step
-#define CG_SETUP_RESULT_VAR(ast, sem_type) \
-CG_RESERVE_RESULT_VAR(ast, sem_type); \
-CG_USE_RESULT_VAR();</code></pre>
-<p>And now armed with this knowledge we can go back to a previous mystery, let’s look at <code>CG_PUSH_EVAL</code> again</p>
-<div class="sourceCode" id="cb121"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb121-1"><a href="#cb121-1" aria-hidden="true" tabindex="-1"></a><span class="co">// Make a temporary buffer for the evaluation results using the canonical naming convention</span></span>
-<span id="cb121-2"><a href="#cb121-2" aria-hidden="true" tabindex="-1"></a><span class="co">// burn the stack slot so that any type and numbered temporary that was needed</span></span>
-<span id="cb121-3"><a href="#cb121-3" aria-hidden="true" tabindex="-1"></a><span class="co">// won&#39;t be re-used until this scope is over.</span></span>
-<span id="cb121-4"><a href="#cb121-4" aria-hidden="true" tabindex="-1"></a><span class="pp">#define CG_PUSH_EVAL(expr, pri) \</span></span>
-<span id="cb121-5"><a href="#cb121-5" aria-hidden="true" tabindex="-1"></a><span class="pp">CHARBUF_OPEN(expr##_is_null); \</span></span>
-<span id="cb121-6"><a href="#cb121-6" aria-hidden="true" tabindex="-1"></a><span class="pp">CHARBUF_OPEN(expr##_value); \</span></span>
-<span id="cb121-7"><a href="#cb121-7" aria-hidden="true" tabindex="-1"></a><span class="pp">cg_expr(expr, &amp;expr##_is_null, &amp;expr##_value, pri); \</span></span>
-<span id="cb121-8"><a href="#cb121-8" aria-hidden="true" tabindex="-1"></a><span class="pp">stack_level++;</span></span></code></pre></div>
-<p>The reason that <code>CG_PUSH_EVAL</code> includes <code>stack_level++</code> is that it is entirely possible, even likely, that the result of <code>cg_expr</code> is in a result variable. The convention is that if the codegen requires a result variable it is allocated <em>first</em> before any other temporaries. This is why there is a way to reserve a variable that you <em>might</em> need. When the codegen is complete, and before anything else happens, <code>stack_level</code> is increased so that the temporary that is holding the result will not be re-used! Any other temporaries are available but the result is still live. This might be easy to get wrong but the macros make it easy to get it right.</p>
-<p>Now, armed with the knowledge that there a result variables and temporary variables and both come from the scratch variable we can resolve the last mystery we left hanging. Why does the scratch variable API accept an AST pointer?</p>
-<p>The only place that pointer can be not null is in the <code>CG_USE_RESULT_VAR</code> macro, it was this line:</p>
-<pre><code>cg_scratch_var(ast_reserved, sem_type_reserved, &amp;result_var, &amp;result_var_is_null, &amp;result_var_value);</code></pre>
-<p>And <code>ast_reserved</code> refers to the AST that we are trying to evaluate. There’s an important special case that we want to optimize that saves a lot of scratch variables. It’s handled by this code in <code>cg_scratch_var</code>:</p>
-<div class="sourceCode" id="cb123"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb123-1"><a href="#cb123-1" aria-hidden="true" tabindex="-1"></a>  <span class="co">// try to avoid creating a scratch variable if we can use the target of an assignment in flight.</span></span>
-<span id="cb123-2"><a href="#cb123-2" aria-hidden="true" tabindex="-1"></a>  <span class="cf">if</span> <span class="op">(</span>is_assignment_target_reusable<span class="op">(</span>ast<span class="op">,</span> sem_type<span class="op">))</span> <span class="op">{</span></span>
-<span id="cb123-3"><a href="#cb123-3" aria-hidden="true" tabindex="-1"></a>    Invariant<span class="op">(</span>ast <span class="op">&amp;&amp;</span> ast<span class="op">-&gt;</span>parent <span class="op">&amp;&amp;</span> ast<span class="op">-&gt;</span>parent<span class="op">-&gt;</span>left<span class="op">);</span></span>
-<span id="cb123-4"><a href="#cb123-4" aria-hidden="true" tabindex="-1"></a>    EXTRACT_ANY_NOTNULL<span class="op">(</span>name_ast<span class="op">,</span> ast<span class="op">-&gt;</span>parent<span class="op">-&gt;</span>left<span class="op">);</span></span>
-<span id="cb123-5"><a href="#cb123-5" aria-hidden="true" tabindex="-1"></a>    EXTRACT_STRING<span class="op">(</span>name<span class="op">,</span> name_ast<span class="op">);</span></span>
-<span id="cb123-6"><a href="#cb123-6" aria-hidden="true" tabindex="-1"></a>    <span class="cf">if</span> <span class="op">(</span>is_out_parameter<span class="op">(</span>name_ast<span class="op">-&gt;</span>sem<span class="op">-&gt;</span>sem_type<span class="op">))</span> <span class="op">{</span></span>
-<span id="cb123-7"><a href="#cb123-7" aria-hidden="true" tabindex="-1"></a>      bprintf<span class="op">(</span>var<span class="op">,</span> <span class="st">&quot;*%s&quot;</span><span class="op">,</span> name<span class="op">);</span></span>
-<span id="cb123-8"><a href="#cb123-8" aria-hidden="true" tabindex="-1"></a>    <span class="op">}</span></span>
-<span id="cb123-9"><a href="#cb123-9" aria-hidden="true" tabindex="-1"></a>    <span class="cf">else</span> <span class="op">{</span></span>
-<span id="cb123-10"><a href="#cb123-10" aria-hidden="true" tabindex="-1"></a>      bprintf<span class="op">(</span>var<span class="op">,</span> <span class="st">&quot;%s&quot;</span><span class="op">,</span> name<span class="op">);</span></span>
-<span id="cb123-11"><a href="#cb123-11" aria-hidden="true" tabindex="-1"></a>    <span class="op">}</span></span>
-<span id="cb123-12"><a href="#cb123-12" aria-hidden="true" tabindex="-1"></a>  <span class="op">}</span></span></code></pre></div>
+<div class="sourceCode" id="cb119"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb119-1"><a href="#cb119-1" aria-hidden="true" tabindex="-1"></a><span class="co">// Make a scratch variable to hold the final result of an evaluation.</span></span>
+<span id="cb119-2"><a href="#cb119-2" aria-hidden="true" tabindex="-1"></a><span class="co">// It may or may not be used.  It should be the first thing you put</span></span>
+<span id="cb119-3"><a href="#cb119-3" aria-hidden="true" tabindex="-1"></a><span class="co">// so that it is on the top of your stack.  This only saves the slot.</span></span>
+<span id="cb119-4"><a href="#cb119-4" aria-hidden="true" tabindex="-1"></a><span class="pp">#define CG_RESERVE_RESULT_VAR(ast, sem_type) \</span></span>
+<span id="cb119-5"><a href="#cb119-5" aria-hidden="true" tabindex="-1"></a><span class="pp">  int32_t stack_level_reserved = stack_level; \</span></span>
+<span id="cb119-6"><a href="#cb119-6" aria-hidden="true" tabindex="-1"></a><span class="pp">  sem_t sem_type_reserved = sem_type; \</span></span>
+<span id="cb119-7"><a href="#cb119-7" aria-hidden="true" tabindex="-1"></a><span class="pp">  ast_node *ast_reserved = ast; \</span></span>
+<span id="cb119-8"><a href="#cb119-8" aria-hidden="true" tabindex="-1"></a><span class="pp">  CHARBUF_OPEN(result_var); \</span></span>
+<span id="cb119-9"><a href="#cb119-9" aria-hidden="true" tabindex="-1"></a><span class="pp">  CHARBUF_OPEN(result_var_is_null); \</span></span>
+<span id="cb119-10"><a href="#cb119-10" aria-hidden="true" tabindex="-1"></a><span class="pp">  CHARBUF_OPEN(result_var_value); \</span></span>
+<span id="cb119-11"><a href="#cb119-11" aria-hidden="true" tabindex="-1"></a><span class="pp">  stack_level++;</span></span></code></pre></div>
+<p>If this looks a lot like <code>PUSH_TEMP</code> that shouldn’t be surprising. The name of the variable and the expression parts always go into <code>charbuf</code> variables named <code>result_var</code>, <code>result_var_is_null</code>, and <code>result_var_value</code> but the scratch variable isn’t actually allocated! However – we burn the stack_level as though it had been allocated.</p>
+<p>The name of the macro provides a clue: this macro reserves a slot for the result variable, it’s used if the codegen might need a result variable, but it might not. If/when the result variable is needed, it we can artificially move the stack level back to the reserved spot, allocate the scratch variable, and then put the stack level back.</p>
+<p>The <code>CG_USE_RESULT_VAR</code> macro does exactly this operation.</p>
+<div class="sourceCode" id="cb120"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb120-1"><a href="#cb120-1" aria-hidden="true" tabindex="-1"></a><span class="co">// If the result variable is going to be used, this writes its name</span></span>
+<span id="cb120-2"><a href="#cb120-2" aria-hidden="true" tabindex="-1"></a><span class="co">// and .value and .is_null into the is_null and value fields.</span></span>
+<span id="cb120-3"><a href="#cb120-3" aria-hidden="true" tabindex="-1"></a><span class="pp">#define CG_USE_RESULT_VAR() \</span></span>
+<span id="cb120-4"><a href="#cb120-4" aria-hidden="true" tabindex="-1"></a><span class="pp">  int32_t stack_level_now = stack_level; \</span></span>
+<span id="cb120-5"><a href="#cb120-5" aria-hidden="true" tabindex="-1"></a><span class="pp">  stack_level = stack_level_reserved; \</span></span>
+<span id="cb120-6"><a href="#cb120-6" aria-hidden="true" tabindex="-1"></a><span class="pp">  cg_scratch_var(ast_reserved, sem_type_reserved, &amp;result_var, &amp;result_var_is_null, &amp;result_var_value); \</span></span>
+<span id="cb120-7"><a href="#cb120-7" aria-hidden="true" tabindex="-1"></a><span class="pp">  stack_level = stack_level_now; \</span></span>
+<span id="cb120-8"><a href="#cb120-8" aria-hidden="true" tabindex="-1"></a><span class="pp">  Invariant(result_var.used &gt; 1); \</span></span>
+<span id="cb120-9"><a href="#cb120-9" aria-hidden="true" tabindex="-1"></a><span class="pp">  bprintf(is_null, &quot;%s&quot;, result_var_is_null.ptr); \</span></span>
+<span id="cb120-10"><a href="#cb120-10" aria-hidden="true" tabindex="-1"></a><span class="pp">  bprintf(value, &quot;%s&quot;, result_var_value.ptr)</span></span></code></pre></div>
+<p>Once the code generator decides that it will in fact be using a result variable to represent the answer, then the <code>is_null</code> and <code>value</code> buffers can be immediately populated to whatever the values were for the result variable. That text will be correct regardless of what codegen is used to populate the variable. The variable is the result.</p>
+<p>There is a simpler macro that reserves and uses the result variable in one step, it’s used frequently. The “reserve” pattern is only necessary when there are some paths that need a result variable and some that don’t.</p>
+<div class="sourceCode" id="cb121"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb121-1"><a href="#cb121-1" aria-hidden="true" tabindex="-1"></a><span class="co">// This does reserve and use in one step</span></span>
+<span id="cb121-2"><a href="#cb121-2" aria-hidden="true" tabindex="-1"></a><span class="pp">#define CG_SETUP_RESULT_VAR(ast, sem_type) \</span></span>
+<span id="cb121-3"><a href="#cb121-3" aria-hidden="true" tabindex="-1"></a><span class="pp">  CG_RESERVE_RESULT_VAR(ast, sem_type); \</span></span>
+<span id="cb121-4"><a href="#cb121-4" aria-hidden="true" tabindex="-1"></a><span class="pp">  CG_USE_RESULT_VAR();</span></span></code></pre></div>
+<p>And now armed with this knowledge we can go back to a previous mystery, let’s look at <code>CG_PUSH_EVAL</code> again:</p>
+<div class="sourceCode" id="cb122"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb122-1"><a href="#cb122-1" aria-hidden="true" tabindex="-1"></a><span class="co">// Make a temporary buffer for the evaluation results using the canonical naming convention</span></span>
+<span id="cb122-2"><a href="#cb122-2" aria-hidden="true" tabindex="-1"></a><span class="co">// burn the stack slot so that any type and numbered temporary that was needed</span></span>
+<span id="cb122-3"><a href="#cb122-3" aria-hidden="true" tabindex="-1"></a><span class="co">// won&#39;t be re-used until this scope is over.</span></span>
+<span id="cb122-4"><a href="#cb122-4" aria-hidden="true" tabindex="-1"></a><span class="pp">#define CG_PUSH_EVAL(expr, pri) \</span></span>
+<span id="cb122-5"><a href="#cb122-5" aria-hidden="true" tabindex="-1"></a><span class="pp">  CHARBUF_OPEN(expr##_is_null); \</span></span>
+<span id="cb122-6"><a href="#cb122-6" aria-hidden="true" tabindex="-1"></a><span class="pp">  CHARBUF_OPEN(expr##_value); \</span></span>
+<span id="cb122-7"><a href="#cb122-7" aria-hidden="true" tabindex="-1"></a><span class="pp">  cg_expr(expr, &amp;expr##_is_null, &amp;expr##_value, pri); \</span></span>
+<span id="cb122-8"><a href="#cb122-8" aria-hidden="true" tabindex="-1"></a><span class="pp">  stack_level++;</span></span></code></pre></div>
+<p>The reason that <code>CG_PUSH_EVAL</code> includes <code>stack_level++</code> is that it is entirely possible, even likely, that the result of <code>cg_expr</code> is in a result variable. The convention is that if the codegen requires a result variable it is allocated <em>first</em>, before any other temporaries. This is why there is a way to reserve a variable that you <em>might</em> need. When the codegen is complete, and before anything else happens, <code>stack_level</code> is increased so that if a temporary is holding the result, it will not be re-used! Any other temporaries are available, but the result is still live. The macros make it easy to get this stack convention consistently correct.</p>
+<p>Now, armed with the knowledge that there are result variables and temporary variables and both come from the scratch variables we can resolve the last mystery we left hanging. Why does the scratch variable API accept an AST pointer?</p>
+<p>The only place that AST pointer can be not null is in the <code>CG_USE_RESULT_VAR</code> macro, it was this line:</p>
+<div class="sourceCode" id="cb123"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb123-1"><a href="#cb123-1" aria-hidden="true" tabindex="-1"></a>cg_scratch_var<span class="op">(</span>ast_reserved<span class="op">,</span> sem_type_reserved<span class="op">,</span> <span class="op">&amp;</span>result_var<span class="op">,</span> <span class="op">&amp;</span>result_var_is_null<span class="op">,</span> <span class="op">&amp;</span>result_var_value<span class="op">);</span></span></code></pre></div>
+<p>And <code>ast_reserved</code> refers to the AST that we are trying to evaluate. There’s an important special case that we want to optimize that saves a lot of scratch variables. That case is handled by this code in <code>cg_scratch_var</code>:</p>
+<div class="sourceCode" id="cb124"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb124-1"><a href="#cb124-1" aria-hidden="true" tabindex="-1"></a>  <span class="co">// try to avoid creating a scratch variable if we can use the target of an assignment in flight.</span></span>
+<span id="cb124-2"><a href="#cb124-2" aria-hidden="true" tabindex="-1"></a>  <span class="cf">if</span> <span class="op">(</span>is_assignment_target_reusable<span class="op">(</span>ast<span class="op">,</span> sem_type<span class="op">))</span> <span class="op">{</span></span>
+<span id="cb124-3"><a href="#cb124-3" aria-hidden="true" tabindex="-1"></a>    Invariant<span class="op">(</span>ast <span class="op">&amp;&amp;</span> ast<span class="op">-&gt;</span>parent <span class="op">&amp;&amp;</span> ast<span class="op">-&gt;</span>parent<span class="op">-&gt;</span>left<span class="op">);</span></span>
+<span id="cb124-4"><a href="#cb124-4" aria-hidden="true" tabindex="-1"></a>    EXTRACT_ANY_NOTNULL<span class="op">(</span>name_ast<span class="op">,</span> ast<span class="op">-&gt;</span>parent<span class="op">-&gt;</span>left<span class="op">);</span></span>
+<span id="cb124-5"><a href="#cb124-5" aria-hidden="true" tabindex="-1"></a>    EXTRACT_STRING<span class="op">(</span>name<span class="op">,</span> name_ast<span class="op">);</span></span>
+<span id="cb124-6"><a href="#cb124-6" aria-hidden="true" tabindex="-1"></a>    <span class="cf">if</span> <span class="op">(</span>is_out_parameter<span class="op">(</span>name_ast<span class="op">-&gt;</span>sem<span class="op">-&gt;</span>sem_type<span class="op">))</span> <span class="op">{</span></span>
+<span id="cb124-7"><a href="#cb124-7" aria-hidden="true" tabindex="-1"></a>      bprintf<span class="op">(</span>var<span class="op">,</span> <span class="st">&quot;*%s&quot;</span><span class="op">,</span> name<span class="op">);</span></span>
+<span id="cb124-8"><a href="#cb124-8" aria-hidden="true" tabindex="-1"></a>    <span class="op">}</span></span>
+<span id="cb124-9"><a href="#cb124-9" aria-hidden="true" tabindex="-1"></a>    <span class="cf">else</span> <span class="op">{</span></span>
+<span id="cb124-10"><a href="#cb124-10" aria-hidden="true" tabindex="-1"></a>      bprintf<span class="op">(</span>var<span class="op">,</span> <span class="st">&quot;%s&quot;</span><span class="op">,</span> name<span class="op">);</span></span>
+<span id="cb124-11"><a href="#cb124-11" aria-hidden="true" tabindex="-1"></a>    <span class="op">}</span></span>
+<span id="cb124-12"><a href="#cb124-12" aria-hidden="true" tabindex="-1"></a>  <span class="op">}</span></span></code></pre></div>
 <p>The idea is that if the generator is doing an assignment like:</p>
-<div class="sourceCode" id="cb124"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb124-1"><a href="#cb124-1" aria-hidden="true" tabindex="-1"></a>  <span class="kw">SET</span> x <span class="op">:=</span> a <span class="op">+</span> b;</span></code></pre></div>
+<div class="sourceCode" id="cb125"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb125-1"><a href="#cb125-1" aria-hidden="true" tabindex="-1"></a>  <span class="kw">SET</span> x <span class="op">:=</span> a <span class="op">+</span> b;</span></code></pre></div>
 <p>Then the code generator doesn’t need a scratch variable to hold the result of the expression <code>a + b</code> like it would in many other contexts. It can use <code>x</code> as the result variable! The <code>SET</code> codegen will discover that the value it’s supposed to set is already in <code>x</code> so it does nothing and everything just works out. The price of this is a call to <code>is_assignment_target_reusable</code> and then some logic to handle the case where <code>x</code> is an out argument (hence call by reference, hence needs to be used as <code>*x</code>).</p>
 <h3 id="basic-control-flow-patterns">Basic Control Flow Patterns</h3>
 <p>To get a sense of how the compiler generates code for statements, we can look at some of the easiest cases.</p>
-<div class="sourceCode" id="cb125"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb125-1"><a href="#cb125-1" aria-hidden="true" tabindex="-1"></a><span class="co">// &quot;While&quot; suffers from the same problem as IF and as a consequence</span></span>
-<span id="cb125-2"><a href="#cb125-2" aria-hidden="true" tabindex="-1"></a><span class="co">// generating while (expression) would not generalize.</span></span>
-<span id="cb125-3"><a href="#cb125-3" aria-hidden="true" tabindex="-1"></a><span class="co">// The overall pattern for while has to look like this:</span></span>
-<span id="cb125-4"><a href="#cb125-4" aria-hidden="true" tabindex="-1"></a><span class="co">//</span></span>
-<span id="cb125-5"><a href="#cb125-5" aria-hidden="true" tabindex="-1"></a><span class="co">//  for (;;) {</span></span>
-<span id="cb125-6"><a href="#cb125-6" aria-hidden="true" tabindex="-1"></a><span class="co">//    prep statements;</span></span>
-<span id="cb125-7"><a href="#cb125-7" aria-hidden="true" tabindex="-1"></a><span class="co">//    condition = final expression;</span></span>
-<span id="cb125-8"><a href="#cb125-8" aria-hidden="true" tabindex="-1"></a><span class="co">//    if (!condition) break;</span></span>
-<span id="cb125-9"><a href="#cb125-9" aria-hidden="true" tabindex="-1"></a><span class="co">//</span></span>
-<span id="cb125-10"><a href="#cb125-10" aria-hidden="true" tabindex="-1"></a><span class="co">//    statements;</span></span>
-<span id="cb125-11"><a href="#cb125-11" aria-hidden="true" tabindex="-1"></a><span class="co">//  }</span></span>
-<span id="cb125-12"><a href="#cb125-12" aria-hidden="true" tabindex="-1"></a><span class="co">//</span></span>
-<span id="cb125-13"><a href="#cb125-13" aria-hidden="true" tabindex="-1"></a><span class="co">// Note that while can have leave and continue substatements which have to map</span></span>
-<span id="cb125-14"><a href="#cb125-14" aria-hidden="true" tabindex="-1"></a><span class="co">// to break and continue.   That means other top level statements that aren&#39;t loops</span></span>
-<span id="cb125-15"><a href="#cb125-15" aria-hidden="true" tabindex="-1"></a><span class="co">// must not create a C loop construct or break/continue would have the wrong target.</span></span>
-<span id="cb125-16"><a href="#cb125-16" aria-hidden="true" tabindex="-1"></a><span class="dt">static</span> <span class="dt">void</span> cg_while_stmt<span class="op">(</span>ast_node <span class="op">*</span>ast<span class="op">)</span> <span class="op">{</span></span>
-<span id="cb125-17"><a href="#cb125-17" aria-hidden="true" tabindex="-1"></a>  Contract<span class="op">(</span>is_ast_while_stmt<span class="op">(</span>ast<span class="op">));</span></span>
-<span id="cb125-18"><a href="#cb125-18" aria-hidden="true" tabindex="-1"></a>  EXTRACT_ANY_NOTNULL<span class="op">(</span>expr<span class="op">,</span> ast<span class="op">-&gt;</span>left<span class="op">);</span></span>
-<span id="cb125-19"><a href="#cb125-19" aria-hidden="true" tabindex="-1"></a>  EXTRACT<span class="op">(</span>stmt_list<span class="op">,</span> ast<span class="op">-&gt;</span>right<span class="op">);</span></span>
-<span id="cb125-20"><a href="#cb125-20" aria-hidden="true" tabindex="-1"></a>  sem_t sem_type <span class="op">=</span> expr<span class="op">-&gt;</span>sem<span class="op">-&gt;</span>sem_type<span class="op">;</span></span>
-<span id="cb125-21"><a href="#cb125-21" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb125-22"><a href="#cb125-22" aria-hidden="true" tabindex="-1"></a>  <span class="co">// WHILE [expr] </span><span class="re">BEGIN</span><span class="co"> [stmt_list] </span><span class="re">END</span></span>
-<span id="cb125-23"><a href="#cb125-23" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb125-24"><a href="#cb125-24" aria-hidden="true" tabindex="-1"></a>  bprintf<span class="op">(</span>cg_main_output<span class="op">,</span> <span class="st">&quot;for (;;) {</span><span class="sc">\n</span><span class="st">&quot;</span><span class="op">);</span></span>
-<span id="cb125-25"><a href="#cb125-25" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb125-26"><a href="#cb125-26" aria-hidden="true" tabindex="-1"></a>  CG_PUSH_EVAL<span class="op">(</span>expr<span class="op">,</span> C_EXPR_PRI_ROOT<span class="op">);</span></span>
-<span id="cb125-27"><a href="#cb125-27" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb125-28"><a href="#cb125-28" aria-hidden="true" tabindex="-1"></a>  <span class="cf">if</span> <span class="op">(</span>is_nullable<span class="op">(</span>sem_type<span class="op">))</span> <span class="op">{</span></span>
-<span id="cb125-29"><a href="#cb125-29" aria-hidden="true" tabindex="-1"></a>    bprintf<span class="op">(</span>cg_main_output<span class="op">,</span> <span class="st">&quot;if (!cql_is_nullable_true(%s, %s)) break;</span><span class="sc">\n</span><span class="st">&quot;</span><span class="op">,</span> expr_is_null<span class="op">.</span>ptr<span class="op">,</span> expr_value<span class="op">.</span>ptr<span class="op">);</span></span>
-<span id="cb125-30"><a href="#cb125-30" aria-hidden="true" tabindex="-1"></a>  <span class="op">}</span></span>
-<span id="cb125-31"><a href="#cb125-31" aria-hidden="true" tabindex="-1"></a>  <span class="cf">else</span> <span class="op">{</span></span>
-<span id="cb125-32"><a href="#cb125-32" aria-hidden="true" tabindex="-1"></a>    bprintf<span class="op">(</span>cg_main_output<span class="op">,</span> <span class="st">&quot;if (!(%s)) break;</span><span class="sc">\n</span><span class="st">&quot;</span><span class="op">,</span> expr_value<span class="op">.</span>ptr<span class="op">);</span></span>
-<span id="cb125-33"><a href="#cb125-33" aria-hidden="true" tabindex="-1"></a>  <span class="op">}</span></span>
-<span id="cb125-34"><a href="#cb125-34" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb125-35"><a href="#cb125-35" aria-hidden="true" tabindex="-1"></a>  bool_t loop_saved <span class="op">=</span> cg_in_loop<span class="op">;</span></span>
-<span id="cb125-36"><a href="#cb125-36" aria-hidden="true" tabindex="-1"></a>  cg_in_loop <span class="op">=</span> true<span class="op">;</span></span>
-<span id="cb125-37"><a href="#cb125-37" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb125-38"><a href="#cb125-38" aria-hidden="true" tabindex="-1"></a>  CG_POP_EVAL<span class="op">(</span>expr<span class="op">);</span></span>
-<span id="cb125-39"><a href="#cb125-39" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb125-40"><a href="#cb125-40" aria-hidden="true" tabindex="-1"></a>  cg_stmt_list<span class="op">(</span>stmt_list<span class="op">);</span></span>
-<span id="cb125-41"><a href="#cb125-41" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb125-42"><a href="#cb125-42" aria-hidden="true" tabindex="-1"></a>  bprintf<span class="op">(</span>cg_main_output<span class="op">,</span> <span class="st">&quot;}</span><span class="sc">\n</span><span class="st">&quot;</span><span class="op">);</span></span>
-<span id="cb125-43"><a href="#cb125-43" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb125-44"><a href="#cb125-44" aria-hidden="true" tabindex="-1"></a>  cg_in_loop <span class="op">=</span> loop_saved<span class="op">;</span></span>
-<span id="cb125-45"><a href="#cb125-45" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span></code></pre></div>
-<p>The comment before the <code>cg_while_stmt</code> actually says it pretty clearly; the issue is that the expression in the while statement might actually require many C statements to evaluate. There are many cases of this sort of thing, but the simplest is probably when any nullable types are in that expression. A particular example illustrates this pretty clearly.</p>
-<div class="sourceCode" id="cb126"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb126-1"><a href="#cb126-1" aria-hidden="true" tabindex="-1"></a>CREATE PROC p <span class="op">()</span></span>
-<span id="cb126-2"><a href="#cb126-2" aria-hidden="true" tabindex="-1"></a>BEGIN</span>
-<span id="cb126-3"><a href="#cb126-3" aria-hidden="true" tabindex="-1"></a>  DECLARE x INTEGER NOT NULL<span class="op">;</span></span>
-<span id="cb126-4"><a href="#cb126-4" aria-hidden="true" tabindex="-1"></a>  SET x <span class="op">:=</span> <span class="dv">1</span><span class="op">;</span></span>
-<span id="cb126-5"><a href="#cb126-5" aria-hidden="true" tabindex="-1"></a>  WHILE x <span class="op">&lt;</span> <span class="dv">5</span></span>
-<span id="cb126-6"><a href="#cb126-6" aria-hidden="true" tabindex="-1"></a>  BEGIN</span>
-<span id="cb126-7"><a href="#cb126-7" aria-hidden="true" tabindex="-1"></a>    SET x <span class="op">:=</span> x <span class="op">+</span> <span class="dv">1</span><span class="op">;</span></span>
-<span id="cb126-8"><a href="#cb126-8" aria-hidden="true" tabindex="-1"></a>  END<span class="op">;</span></span>
-<span id="cb126-9"><a href="#cb126-9" aria-hidden="true" tabindex="-1"></a>END<span class="op">;</span></span>
-<span id="cb126-10"><a href="#cb126-10" aria-hidden="true" tabindex="-1"></a><span class="op">*/</span></span>
-<span id="cb126-11"><a href="#cb126-11" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb126-12"><a href="#cb126-12" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> p<span class="op">(</span><span class="dt">void</span><span class="op">)</span> <span class="op">{</span></span>
-<span id="cb126-13"><a href="#cb126-13" aria-hidden="true" tabindex="-1"></a>  cql_int32 x <span class="op">=</span> <span class="dv">0</span><span class="op">;</span></span>
-<span id="cb126-14"><a href="#cb126-14" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb126-15"><a href="#cb126-15" aria-hidden="true" tabindex="-1"></a>  x <span class="op">=</span> <span class="dv">1</span><span class="op">;</span></span>
-<span id="cb126-16"><a href="#cb126-16" aria-hidden="true" tabindex="-1"></a>  <span class="cf">for</span> <span class="op">(;;)</span> <span class="op">{</span></span>
-<span id="cb126-17"><a href="#cb126-17" aria-hidden="true" tabindex="-1"></a>  <span class="co">/* in trickier cases there would be code right here */</span></span>
-<span id="cb126-18"><a href="#cb126-18" aria-hidden="true" tabindex="-1"></a>  <span class="cf">if</span> <span class="op">(!(</span>x <span class="op">&lt;</span> <span class="dv">5</span><span class="op">))</span> <span class="cf">break</span><span class="op">;</span></span>
-<span id="cb126-19"><a href="#cb126-19" aria-hidden="true" tabindex="-1"></a>    x <span class="op">=</span> x <span class="op">+</span> <span class="dv">1</span><span class="op">;</span></span>
-<span id="cb126-20"><a href="#cb126-20" aria-hidden="true" tabindex="-1"></a>  <span class="op">}</span></span>
-<span id="cb126-21"><a href="#cb126-21" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span></code></pre></div>
-<p>In this case, the <code>while</code> pattern could have been used because the condition is simply <code>x &lt; 5</code> so this whole pattern is overkill. But consider this program just a tiny bit different.</p>
-<div class="sourceCode" id="cb127"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb127-1"><a href="#cb127-1" aria-hidden="true" tabindex="-1"></a><span class="co">/*</span></span>
-<span id="cb127-2"><a href="#cb127-2" aria-hidden="true" tabindex="-1"></a><span class="co">CREATE PROC p ()</span></span>
-<span id="cb127-3"><a href="#cb127-3" aria-hidden="true" tabindex="-1"></a><span class="re">BEGIN</span></span>
-<span id="cb127-4"><a href="#cb127-4" aria-hidden="true" tabindex="-1"></a><span class="co">  DECLARE x INTEGER;  -- x is nullable</span></span>
-<span id="cb127-5"><a href="#cb127-5" aria-hidden="true" tabindex="-1"></a><span class="co">  SET x := 1;</span></span>
-<span id="cb127-6"><a href="#cb127-6" aria-hidden="true" tabindex="-1"></a><span class="co">  WHILE x &lt; 5</span></span>
-<span id="cb127-7"><a href="#cb127-7" aria-hidden="true" tabindex="-1"></a><span class="co">  </span><span class="re">BEGIN</span></span>
-<span id="cb127-8"><a href="#cb127-8" aria-hidden="true" tabindex="-1"></a><span class="co">    SET x := x + 1;</span></span>
-<span id="cb127-9"><a href="#cb127-9" aria-hidden="true" tabindex="-1"></a><span class="co">  </span><span class="re">END</span><span class="co">;</span></span>
-<span id="cb127-10"><a href="#cb127-10" aria-hidden="true" tabindex="-1"></a><span class="re">END</span><span class="co">;</span></span>
-<span id="cb127-11"><a href="#cb127-11" aria-hidden="true" tabindex="-1"></a><span class="co">*/</span></span>
-<span id="cb127-12"><a href="#cb127-12" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb127-13"><a href="#cb127-13" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> p<span class="op">(</span><span class="dt">void</span><span class="op">)</span> <span class="op">{</span></span>
-<span id="cb127-14"><a href="#cb127-14" aria-hidden="true" tabindex="-1"></a>  cql_nullable_int32 x<span class="op">;</span></span>
-<span id="cb127-15"><a href="#cb127-15" aria-hidden="true" tabindex="-1"></a>  cql_set_null<span class="op">(</span>x<span class="op">);</span></span>
-<span id="cb127-16"><a href="#cb127-16" aria-hidden="true" tabindex="-1"></a>  cql_nullable_bool _tmp_n_bool_0<span class="op">;</span></span>
-<span id="cb127-17"><a href="#cb127-17" aria-hidden="true" tabindex="-1"></a>  cql_set_null<span class="op">(</span>_tmp_n_bool_0<span class="op">);</span></span>
-<span id="cb127-18"><a href="#cb127-18" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb127-19"><a href="#cb127-19" aria-hidden="true" tabindex="-1"></a>  cql_set_notnull<span class="op">(</span>x<span class="op">,</span> <span class="dv">1</span><span class="op">);</span></span>
-<span id="cb127-20"><a href="#cb127-20" aria-hidden="true" tabindex="-1"></a>  <span class="cf">for</span> <span class="op">(;;)</span> <span class="op">{</span></span>
-<span id="cb127-21"><a href="#cb127-21" aria-hidden="true" tabindex="-1"></a>  cql_set_nullable<span class="op">(</span>_tmp_n_bool_0<span class="op">,</span> x<span class="op">.</span>is_null<span class="op">,</span> x<span class="op">.</span>value <span class="op">&lt;</span> <span class="dv">5</span><span class="op">);</span></span>
-<span id="cb127-22"><a href="#cb127-22" aria-hidden="true" tabindex="-1"></a>  <span class="cf">if</span> <span class="op">(!</span>cql_is_nullable_true<span class="op">(</span>_tmp_n_bool_0<span class="op">.</span>is_null<span class="op">,</span> _tmp_n_bool_0<span class="op">.</span>value<span class="op">))</span> <span class="cf">break</span><span class="op">;</span></span>
-<span id="cb127-23"><a href="#cb127-23" aria-hidden="true" tabindex="-1"></a>    cql_set_nullable<span class="op">(</span>x<span class="op">,</span> x<span class="op">.</span>is_null<span class="op">,</span> x<span class="op">.</span>value <span class="op">+</span> <span class="dv">1</span><span class="op">);</span></span>
-<span id="cb127-24"><a href="#cb127-24" aria-hidden="true" tabindex="-1"></a>  <span class="op">}</span></span>
-<span id="cb127-25"><a href="#cb127-25" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span></code></pre></div>
-<p>Even for this small little case, the nullable arithmetic macros have to be used to keep <code>x</code> up to date. The result of <code>x &lt; 5</code> is of type “bool” rather than “bool not null” so a temporary variable captures the result of the expression. This is an easy case but similar things happen if the expression includes <code>CASE...WHEN...</code> or <code>IN</code> constructs. There are many other cases.</p>
+<div class="sourceCode" id="cb126"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb126-1"><a href="#cb126-1" aria-hidden="true" tabindex="-1"></a><span class="co">// &quot;While&quot; suffers from the same problem as IF and as a consequence</span></span>
+<span id="cb126-2"><a href="#cb126-2" aria-hidden="true" tabindex="-1"></a><span class="co">// generating while (expression) would not generalize.</span></span>
+<span id="cb126-3"><a href="#cb126-3" aria-hidden="true" tabindex="-1"></a><span class="co">// The overall pattern for while has to look like this:</span></span>
+<span id="cb126-4"><a href="#cb126-4" aria-hidden="true" tabindex="-1"></a><span class="co">//</span></span>
+<span id="cb126-5"><a href="#cb126-5" aria-hidden="true" tabindex="-1"></a><span class="co">//  for (;;) {</span></span>
+<span id="cb126-6"><a href="#cb126-6" aria-hidden="true" tabindex="-1"></a><span class="co">//    prep statements;</span></span>
+<span id="cb126-7"><a href="#cb126-7" aria-hidden="true" tabindex="-1"></a><span class="co">//    condition = final expression;</span></span>
+<span id="cb126-8"><a href="#cb126-8" aria-hidden="true" tabindex="-1"></a><span class="co">//    if (!condition) break;</span></span>
+<span id="cb126-9"><a href="#cb126-9" aria-hidden="true" tabindex="-1"></a><span class="co">//</span></span>
+<span id="cb126-10"><a href="#cb126-10" aria-hidden="true" tabindex="-1"></a><span class="co">//    statements;</span></span>
+<span id="cb126-11"><a href="#cb126-11" aria-hidden="true" tabindex="-1"></a><span class="co">//  }</span></span>
+<span id="cb126-12"><a href="#cb126-12" aria-hidden="true" tabindex="-1"></a><span class="co">//</span></span>
+<span id="cb126-13"><a href="#cb126-13" aria-hidden="true" tabindex="-1"></a><span class="co">// Note that while can have leave and continue substatements which have to map</span></span>
+<span id="cb126-14"><a href="#cb126-14" aria-hidden="true" tabindex="-1"></a><span class="co">// to break and continue.   That means other top level statements that aren&#39;t loops</span></span>
+<span id="cb126-15"><a href="#cb126-15" aria-hidden="true" tabindex="-1"></a><span class="co">// must not create a C loop construct or break/continue would have the wrong target.</span></span>
+<span id="cb126-16"><a href="#cb126-16" aria-hidden="true" tabindex="-1"></a><span class="dt">static</span> <span class="dt">void</span> cg_while_stmt<span class="op">(</span>ast_node <span class="op">*</span>ast<span class="op">)</span> <span class="op">{</span></span>
+<span id="cb126-17"><a href="#cb126-17" aria-hidden="true" tabindex="-1"></a>  Contract<span class="op">(</span>is_ast_while_stmt<span class="op">(</span>ast<span class="op">));</span></span>
+<span id="cb126-18"><a href="#cb126-18" aria-hidden="true" tabindex="-1"></a>  EXTRACT_ANY_NOTNULL<span class="op">(</span>expr<span class="op">,</span> ast<span class="op">-&gt;</span>left<span class="op">);</span></span>
+<span id="cb126-19"><a href="#cb126-19" aria-hidden="true" tabindex="-1"></a>  EXTRACT<span class="op">(</span>stmt_list<span class="op">,</span> ast<span class="op">-&gt;</span>right<span class="op">);</span></span>
+<span id="cb126-20"><a href="#cb126-20" aria-hidden="true" tabindex="-1"></a>  sem_t sem_type <span class="op">=</span> expr<span class="op">-&gt;</span>sem<span class="op">-&gt;</span>sem_type<span class="op">;</span></span>
+<span id="cb126-21"><a href="#cb126-21" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb126-22"><a href="#cb126-22" aria-hidden="true" tabindex="-1"></a>  <span class="co">// WHILE [expr] </span><span class="re">BEGIN</span><span class="co"> [stmt_list] </span><span class="re">END</span></span>
+<span id="cb126-23"><a href="#cb126-23" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb126-24"><a href="#cb126-24" aria-hidden="true" tabindex="-1"></a>  bprintf<span class="op">(</span>cg_main_output<span class="op">,</span> <span class="st">&quot;for (;;) {</span><span class="sc">\n</span><span class="st">&quot;</span><span class="op">);</span></span>
+<span id="cb126-25"><a href="#cb126-25" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb126-26"><a href="#cb126-26" aria-hidden="true" tabindex="-1"></a>  CG_PUSH_EVAL<span class="op">(</span>expr<span class="op">,</span> C_EXPR_PRI_ROOT<span class="op">);</span></span>
+<span id="cb126-27"><a href="#cb126-27" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb126-28"><a href="#cb126-28" aria-hidden="true" tabindex="-1"></a>  <span class="cf">if</span> <span class="op">(</span>is_nullable<span class="op">(</span>sem_type<span class="op">))</span> <span class="op">{</span></span>
+<span id="cb126-29"><a href="#cb126-29" aria-hidden="true" tabindex="-1"></a>    bprintf<span class="op">(</span>cg_main_output<span class="op">,</span> <span class="st">&quot;if (!cql_is_nullable_true(%s, %s)) break;</span><span class="sc">\n</span><span class="st">&quot;</span><span class="op">,</span> expr_is_null<span class="op">.</span>ptr<span class="op">,</span> expr_value<span class="op">.</span>ptr<span class="op">);</span></span>
+<span id="cb126-30"><a href="#cb126-30" aria-hidden="true" tabindex="-1"></a>  <span class="op">}</span></span>
+<span id="cb126-31"><a href="#cb126-31" aria-hidden="true" tabindex="-1"></a>  <span class="cf">else</span> <span class="op">{</span></span>
+<span id="cb126-32"><a href="#cb126-32" aria-hidden="true" tabindex="-1"></a>    bprintf<span class="op">(</span>cg_main_output<span class="op">,</span> <span class="st">&quot;if (!(%s)) break;</span><span class="sc">\n</span><span class="st">&quot;</span><span class="op">,</span> expr_value<span class="op">.</span>ptr<span class="op">);</span></span>
+<span id="cb126-33"><a href="#cb126-33" aria-hidden="true" tabindex="-1"></a>  <span class="op">}</span></span>
+<span id="cb126-34"><a href="#cb126-34" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb126-35"><a href="#cb126-35" aria-hidden="true" tabindex="-1"></a>  bool_t loop_saved <span class="op">=</span> cg_in_loop<span class="op">;</span></span>
+<span id="cb126-36"><a href="#cb126-36" aria-hidden="true" tabindex="-1"></a>  cg_in_loop <span class="op">=</span> true<span class="op">;</span></span>
+<span id="cb126-37"><a href="#cb126-37" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb126-38"><a href="#cb126-38" aria-hidden="true" tabindex="-1"></a>  CG_POP_EVAL<span class="op">(</span>expr<span class="op">);</span></span>
+<span id="cb126-39"><a href="#cb126-39" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb126-40"><a href="#cb126-40" aria-hidden="true" tabindex="-1"></a>  cg_stmt_list<span class="op">(</span>stmt_list<span class="op">);</span></span>
+<span id="cb126-41"><a href="#cb126-41" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb126-42"><a href="#cb126-42" aria-hidden="true" tabindex="-1"></a>  bprintf<span class="op">(</span>cg_main_output<span class="op">,</span> <span class="st">&quot;}</span><span class="sc">\n</span><span class="st">&quot;</span><span class="op">);</span></span>
+<span id="cb126-43"><a href="#cb126-43" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb126-44"><a href="#cb126-44" aria-hidden="true" tabindex="-1"></a>  cg_in_loop <span class="op">=</span> loop_saved<span class="op">;</span></span>
+<span id="cb126-45"><a href="#cb126-45" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span></code></pre></div>
+<p>The comment before the <code>cg_while_stmt</code> actually describes the situation pretty clearly; the issue with this codegen is that the expression in the while statement might actually require many C statements to evaluate. There are many cases of this sort of thing, but the simplest is probably when any nullable types are in that expression. A particular example illustrates this pretty clearly:</p>
+<div class="sourceCode" id="cb127"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb127-1"><a href="#cb127-1" aria-hidden="true" tabindex="-1"></a><span class="kw">CREATE</span> PROC p ()</span>
+<span id="cb127-2"><a href="#cb127-2" aria-hidden="true" tabindex="-1"></a><span class="cf">BEGIN</span></span>
+<span id="cb127-3"><a href="#cb127-3" aria-hidden="true" tabindex="-1"></a>  <span class="kw">DECLARE</span> x <span class="dt">INTEGER</span> <span class="kw">NOT</span> <span class="kw">NULL</span>;</span>
+<span id="cb127-4"><a href="#cb127-4" aria-hidden="true" tabindex="-1"></a>  <span class="kw">SET</span> x <span class="op">:=</span> <span class="dv">1</span>;</span>
+<span id="cb127-5"><a href="#cb127-5" aria-hidden="true" tabindex="-1"></a>  <span class="cf">WHILE</span> x <span class="op">&lt;</span> <span class="dv">5</span></span>
+<span id="cb127-6"><a href="#cb127-6" aria-hidden="true" tabindex="-1"></a>  <span class="cf">BEGIN</span></span>
+<span id="cb127-7"><a href="#cb127-7" aria-hidden="true" tabindex="-1"></a>    <span class="kw">SET</span> x <span class="op">:=</span> x <span class="op">+</span> <span class="dv">1</span>;</span>
+<span id="cb127-8"><a href="#cb127-8" aria-hidden="true" tabindex="-1"></a>  <span class="cf">END</span>;</span>
+<span id="cb127-9"><a href="#cb127-9" aria-hidden="true" tabindex="-1"></a><span class="cf">END</span>;</span></code></pre></div>
+<p>which generates:</p>
+<div class="sourceCode" id="cb128"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb128-1"><a href="#cb128-1" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> p<span class="op">(</span><span class="dt">void</span><span class="op">)</span> <span class="op">{</span></span>
+<span id="cb128-2"><a href="#cb128-2" aria-hidden="true" tabindex="-1"></a>  cql_int32 x <span class="op">=</span> <span class="dv">0</span><span class="op">;</span></span>
+<span id="cb128-3"><a href="#cb128-3" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb128-4"><a href="#cb128-4" aria-hidden="true" tabindex="-1"></a>  x <span class="op">=</span> <span class="dv">1</span><span class="op">;</span></span>
+<span id="cb128-5"><a href="#cb128-5" aria-hidden="true" tabindex="-1"></a>  <span class="cf">for</span> <span class="op">(;;)</span> <span class="op">{</span></span>
+<span id="cb128-6"><a href="#cb128-6" aria-hidden="true" tabindex="-1"></a>  <span class="co">/* in trickier cases there would be code right here */</span></span>
+<span id="cb128-7"><a href="#cb128-7" aria-hidden="true" tabindex="-1"></a>  <span class="cf">if</span> <span class="op">(!(</span>x <span class="op">&lt;</span> <span class="dv">5</span><span class="op">))</span> <span class="cf">break</span><span class="op">;</span></span>
+<span id="cb128-8"><a href="#cb128-8" aria-hidden="true" tabindex="-1"></a>    x <span class="op">=</span> x <span class="op">+</span> <span class="dv">1</span><span class="op">;</span></span>
+<span id="cb128-9"><a href="#cb128-9" aria-hidden="true" tabindex="-1"></a>  <span class="op">}</span></span>
+<span id="cb128-10"><a href="#cb128-10" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span></code></pre></div>
+<p>In this case, a <code>while</code> statement could have been used because the condition is simply <code>x &lt; 5</code> so this more general pattern is overkill. But consider this program, just a tiny bit different:</p>
+<div class="sourceCode" id="cb129"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb129-1"><a href="#cb129-1" aria-hidden="true" tabindex="-1"></a><span class="kw">CREATE</span> PROC p ()</span>
+<span id="cb129-2"><a href="#cb129-2" aria-hidden="true" tabindex="-1"></a><span class="cf">BEGIN</span></span>
+<span id="cb129-3"><a href="#cb129-3" aria-hidden="true" tabindex="-1"></a>  <span class="kw">DECLARE</span> x <span class="dt">INTEGER</span>;  <span class="co">-- x is nullable</span></span>
+<span id="cb129-4"><a href="#cb129-4" aria-hidden="true" tabindex="-1"></a>  <span class="kw">SET</span> x <span class="op">:=</span> <span class="dv">1</span>;</span>
+<span id="cb129-5"><a href="#cb129-5" aria-hidden="true" tabindex="-1"></a>  <span class="cf">WHILE</span> x <span class="op">&lt;</span> <span class="dv">5</span></span>
+<span id="cb129-6"><a href="#cb129-6" aria-hidden="true" tabindex="-1"></a>  <span class="cf">BEGIN</span></span>
+<span id="cb129-7"><a href="#cb129-7" aria-hidden="true" tabindex="-1"></a>    <span class="kw">SET</span> x <span class="op">:=</span> x <span class="op">+</span> <span class="dv">1</span>;</span>
+<span id="cb129-8"><a href="#cb129-8" aria-hidden="true" tabindex="-1"></a>  <span class="cf">END</span>;</span>
+<span id="cb129-9"><a href="#cb129-9" aria-hidden="true" tabindex="-1"></a><span class="cf">END</span>;</span></code></pre></div>
+<p>which produces:</p>
+<div class="sourceCode" id="cb130"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb130-1"><a href="#cb130-1" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> p<span class="op">(</span><span class="dt">void</span><span class="op">)</span> <span class="op">{</span></span>
+<span id="cb130-2"><a href="#cb130-2" aria-hidden="true" tabindex="-1"></a>  cql_nullable_int32 x<span class="op">;</span></span>
+<span id="cb130-3"><a href="#cb130-3" aria-hidden="true" tabindex="-1"></a>  cql_set_null<span class="op">(</span>x<span class="op">);</span></span>
+<span id="cb130-4"><a href="#cb130-4" aria-hidden="true" tabindex="-1"></a>  cql_nullable_bool _tmp_n_bool_0<span class="op">;</span></span>
+<span id="cb130-5"><a href="#cb130-5" aria-hidden="true" tabindex="-1"></a>  cql_set_null<span class="op">(</span>_tmp_n_bool_0<span class="op">);</span></span>
+<span id="cb130-6"><a href="#cb130-6" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb130-7"><a href="#cb130-7" aria-hidden="true" tabindex="-1"></a>  cql_set_notnull<span class="op">(</span>x<span class="op">,</span> <span class="dv">1</span><span class="op">);</span></span>
+<span id="cb130-8"><a href="#cb130-8" aria-hidden="true" tabindex="-1"></a>  <span class="cf">for</span> <span class="op">(;;)</span> <span class="op">{</span></span>
+<span id="cb130-9"><a href="#cb130-9" aria-hidden="true" tabindex="-1"></a>  cql_set_nullable<span class="op">(</span>_tmp_n_bool_0<span class="op">,</span> x<span class="op">.</span>is_null<span class="op">,</span> x<span class="op">.</span>value <span class="op">&lt;</span> <span class="dv">5</span><span class="op">);</span></span>
+<span id="cb130-10"><a href="#cb130-10" aria-hidden="true" tabindex="-1"></a>  <span class="cf">if</span> <span class="op">(!</span>cql_is_nullable_true<span class="op">(</span>_tmp_n_bool_0<span class="op">.</span>is_null<span class="op">,</span> _tmp_n_bool_0<span class="op">.</span>value<span class="op">))</span> <span class="cf">break</span><span class="op">;</span></span>
+<span id="cb130-11"><a href="#cb130-11" aria-hidden="true" tabindex="-1"></a>    cql_set_nullable<span class="op">(</span>x<span class="op">,</span> x<span class="op">.</span>is_null<span class="op">,</span> x<span class="op">.</span>value <span class="op">+</span> <span class="dv">1</span><span class="op">);</span></span>
+<span id="cb130-12"><a href="#cb130-12" aria-hidden="true" tabindex="-1"></a>  <span class="op">}</span></span>
+<span id="cb130-13"><a href="#cb130-13" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span></code></pre></div>
+<p>Even for this small little case, the nullable arithmetic macros have to be used to keep <code>x</code> up to date. The result of <code>x &lt; 5</code> is of type <code>BOOL</code> rather than <code>BOOL NOT NULL</code> so a temporary variable captures the result of the expression. This is an easy case, but similar things happen if the expression includes e.g. <code>CASE...WHEN...</code> or <code>IN</code> constructs. There are many other cases.</p>
 <p>So with this in mind, let’s reconsider what <code>cg_while_stmt</code> is doing:</p>
 <ul>
 <li>we start the <code>for</code> statement in the output
@@ -2729,164 +2809,1036 @@ CG_USE_RESULT_VAR();</code></pre>
 <li>we recurse to do more statements with <code>cg_stmt_list</code></li>
 <li>finally we end the <code>for</code> that we began</li>
 </ul>
-<p>This kind of structure is common to all the control flow cases. Generally, we have to deal with the fact that CQL expressions become C statements so we use a more general flow control strategy. But with this in mind, it’s easy to imagine how <code>IF</code> <code>LOOP</code> and <code>SWITCH</code> are handled.</p>
+<p>This kind of structure is common to all the control flow cases. Generally, we have to deal with the fact that CQL expressions often become C statements so we use a more general flow control strategy. But with this in mind, it’s easy to imagine how the <code>IF</code>, <code>LOOP</code>, and <code>SWITCH</code> switch statements are handled.</p>
 <h3 id="cleanup-and-errors">Cleanup and Errors</h3>
 <p>There are a number of places where things can go wrong when running a CQL procedure. The most common sources are: (1) SQLite APIs, almost all of which can fail, and, (2) calling other procedures which also might fail. Here’s a very simple example:</p>
-<div class="sourceCode" id="cb128"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb128-1"><a href="#cb128-1" aria-hidden="true" tabindex="-1"></a><span class="co">/*</span></span>
-<span id="cb128-2"><a href="#cb128-2" aria-hidden="true" tabindex="-1"></a><span class="co">DECLARE PROC something_that_might_fail (arg TEXT) USING TRANSACTION;</span></span>
-<span id="cb128-3"><a href="#cb128-3" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb128-4"><a href="#cb128-4" aria-hidden="true" tabindex="-1"></a><span class="co">CREATE PROC p ()</span></span>
-<span id="cb128-5"><a href="#cb128-5" aria-hidden="true" tabindex="-1"></a><span class="re">BEGIN</span></span>
-<span id="cb128-6"><a href="#cb128-6" aria-hidden="true" tabindex="-1"></a><span class="co">  LET arg := &quot;test&quot;;</span></span>
-<span id="cb128-7"><a href="#cb128-7" aria-hidden="true" tabindex="-1"></a><span class="co">  CALL something_that_might_fail(arg);</span></span>
-<span id="cb128-8"><a href="#cb128-8" aria-hidden="true" tabindex="-1"></a><span class="re">END</span><span class="co">;</span></span>
-<span id="cb128-9"><a href="#cb128-9" aria-hidden="true" tabindex="-1"></a><span class="co">*/</span></span>
-<span id="cb128-10"><a href="#cb128-10" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb128-11"><a href="#cb128-11" aria-hidden="true" tabindex="-1"></a>cql_string_literal<span class="op">(</span>_literal_1_test_p<span class="op">,</span> <span class="st">&quot;test&quot;</span><span class="op">);</span></span>
-<span id="cb128-12"><a href="#cb128-12" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb128-13"><a href="#cb128-13" aria-hidden="true" tabindex="-1"></a>CQL_WARN_UNUSED cql_code p<span class="op">(</span>sqlite3 <span class="op">*</span>_Nonnull _db_<span class="op">)</span> <span class="op">{</span></span>
-<span id="cb128-14"><a href="#cb128-14" aria-hidden="true" tabindex="-1"></a>  cql_code _rc_ <span class="op">=</span> SQLITE_OK<span class="op">;</span></span>
-<span id="cb128-15"><a href="#cb128-15" aria-hidden="true" tabindex="-1"></a>  cql_string_ref arg <span class="op">=</span> NULL<span class="op">;</span></span>
-<span id="cb128-16"><a href="#cb128-16" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb128-17"><a href="#cb128-17" aria-hidden="true" tabindex="-1"></a>  cql_set_string_ref<span class="op">(&amp;</span>arg<span class="op">,</span> _literal_1_test_p<span class="op">);</span></span>
-<span id="cb128-18"><a href="#cb128-18" aria-hidden="true" tabindex="-1"></a>  _rc_ <span class="op">=</span> something_that_might_fail<span class="op">(</span>_db_<span class="op">,</span> arg<span class="op">);</span></span>
-<span id="cb128-19"><a href="#cb128-19" aria-hidden="true" tabindex="-1"></a>  <span class="cf">if</span> <span class="op">(</span>_rc_ <span class="op">!=</span> SQLITE_OK<span class="op">)</span> <span class="op">{</span> cql_error_trace<span class="op">();</span> <span class="cf">goto</span> cql_cleanup<span class="op">;</span> <span class="op">}</span></span>
-<span id="cb128-20"><a href="#cb128-20" aria-hidden="true" tabindex="-1"></a>  _rc_ <span class="op">=</span> SQLITE_OK<span class="op">;</span></span>
-<span id="cb128-21"><a href="#cb128-21" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb128-22"><a href="#cb128-22" aria-hidden="true" tabindex="-1"></a>cql_cleanup<span class="op">:</span></span>
-<span id="cb128-23"><a href="#cb128-23" aria-hidden="true" tabindex="-1"></a>  cql_string_release<span class="op">(</span>arg<span class="op">);</span></span>
-<span id="cb128-24"><a href="#cb128-24" aria-hidden="true" tabindex="-1"></a>  <span class="cf">return</span> _rc_<span class="op">;</span></span>
-<span id="cb128-25"><a href="#cb128-25" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span></code></pre></div>
-<p>Let’s look at this carefully:</p>
+<div class="sourceCode" id="cb131"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb131-1"><a href="#cb131-1" aria-hidden="true" tabindex="-1"></a><span class="kw">DECLARE</span> PROC something_that_might_fail (arg TEXT) <span class="kw">USING</span> <span class="kw">TRANSACTION</span>;</span>
+<span id="cb131-2"><a href="#cb131-2" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb131-3"><a href="#cb131-3" aria-hidden="true" tabindex="-1"></a><span class="kw">CREATE</span> PROC p ()</span>
+<span id="cb131-4"><a href="#cb131-4" aria-hidden="true" tabindex="-1"></a><span class="cf">BEGIN</span></span>
+<span id="cb131-5"><a href="#cb131-5" aria-hidden="true" tabindex="-1"></a>  LET arg <span class="op">:=</span> <span class="ot">&quot;test&quot;</span>;</span>
+<span id="cb131-6"><a href="#cb131-6" aria-hidden="true" tabindex="-1"></a>  <span class="kw">CALL</span> something_that_might_fail(arg);</span>
+<span id="cb131-7"><a href="#cb131-7" aria-hidden="true" tabindex="-1"></a><span class="cf">END</span>;</span></code></pre></div>
+<p>Which generates:</p>
+<div class="sourceCode" id="cb132"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb132-1"><a href="#cb132-1" aria-hidden="true" tabindex="-1"></a>cql_string_literal<span class="op">(</span>_literal_1_test_p<span class="op">,</span> <span class="st">&quot;test&quot;</span><span class="op">);</span></span>
+<span id="cb132-2"><a href="#cb132-2" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb132-3"><a href="#cb132-3" aria-hidden="true" tabindex="-1"></a>CQL_WARN_UNUSED cql_code p<span class="op">(</span>sqlite3 <span class="op">*</span>_Nonnull _db_<span class="op">)</span> <span class="op">{</span></span>
+<span id="cb132-4"><a href="#cb132-4" aria-hidden="true" tabindex="-1"></a>  cql_code _rc_ <span class="op">=</span> SQLITE_OK<span class="op">;</span></span>
+<span id="cb132-5"><a href="#cb132-5" aria-hidden="true" tabindex="-1"></a>  cql_string_ref arg <span class="op">=</span> NULL<span class="op">;</span></span>
+<span id="cb132-6"><a href="#cb132-6" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb132-7"><a href="#cb132-7" aria-hidden="true" tabindex="-1"></a>  cql_set_string_ref<span class="op">(&amp;</span>arg<span class="op">,</span> _literal_1_test_p<span class="op">);</span></span>
+<span id="cb132-8"><a href="#cb132-8" aria-hidden="true" tabindex="-1"></a>  _rc_ <span class="op">=</span> something_that_might_fail<span class="op">(</span>_db_<span class="op">,</span> arg<span class="op">);</span></span>
+<span id="cb132-9"><a href="#cb132-9" aria-hidden="true" tabindex="-1"></a>  <span class="cf">if</span> <span class="op">(</span>_rc_ <span class="op">!=</span> SQLITE_OK<span class="op">)</span> <span class="op">{</span> cql_error_trace<span class="op">();</span> <span class="cf">goto</span> cql_cleanup<span class="op">;</span> <span class="op">}</span></span>
+<span id="cb132-10"><a href="#cb132-10" aria-hidden="true" tabindex="-1"></a>  _rc_ <span class="op">=</span> SQLITE_OK<span class="op">;</span></span>
+<span id="cb132-11"><a href="#cb132-11" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb132-12"><a href="#cb132-12" aria-hidden="true" tabindex="-1"></a>cql_cleanup<span class="op">:</span></span>
+<span id="cb132-13"><a href="#cb132-13" aria-hidden="true" tabindex="-1"></a>  cql_string_release<span class="op">(</span>arg<span class="op">);</span></span>
+<span id="cb132-14"><a href="#cb132-14" aria-hidden="true" tabindex="-1"></a>  <span class="cf">return</span> _rc_<span class="op">;</span></span>
+<span id="cb132-15"><a href="#cb132-15" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span></code></pre></div>
+<p>Let’s look at those fragments carefully:</p>
 <ul>
 <li>first, we had to declare <code>something_that_might_fail</code>
 <ul>
-<li>the declaration includes <code>USING TRANSACTION</code> indicating the procedure uses the database</li>
-<li>we didn’t provide the definition, that will lead to a link time error but we’re ignoring that for now</li>
+<li>the declaration included <code>USING TRANSACTION</code> indicating the procedure uses the database</li>
+<li>we didn’t provide the procedure definition, this is like an <code>extern ... foo(...);</code> declaration</li>
 </ul></li>
 <li>there is a string literal named <code>_literal_1_test_p</code> that is auto-created
 <ul>
 <li><code>cql_string_literal</code> can expand into a variety of things, whatever you want “make a string literal” to mean</li>
-<li>its defined in <code>cqlrt.h</code> and it’s designed to be replaced</li>
+<li>it’s defined in <code>cqlrt.h</code> and it’s designed to be replaced</li>
 </ul></li>
 <li><code>cql_set_string_ref(&amp;arg, _literal_1_test_p);</code> is expected to “retain” the string (+1 ref count)</li>
-<li><code>cql_cleanup</code> is the exit label, this code will run for sure
+<li><code>cql_cleanup</code> is the exit label, this cleanup code will run on all exit paths
 <ul>
 <li>cleanup statements are accumulated by writing to <code>cg_cleanup_output</code> which usually writes to the <code>proc_cleanup</code> buffer</li>
 <li>because cleanup is in its own buffer you can add to it freely whenever a new declaration that requires cleanup arises</li>
-<li>in this case the declaration of the string literal caused the <code>C</code> variable <code>arg</code> to be created and also the cleanup code</li>
+<li>in this case the declaration of the string variable caused the <code>C</code> variable <code>arg</code> to be created and also the cleanup code</li>
 </ul></li>
 <li>now we call <code>something_that_might_fail</code> passing it our database pointer and the argument</li>
 <li>the hidden <code>_db_</code> pointer is passed to all procedures that use the database</li>
-<li>these are also the ones that can fail</li>
-<li>any failed return code (not <code>SQLITE_OK</code>) causes two things
+<li>these procedures are also the ones that can fail</li>
+<li>any failed return code (not <code>SQLITE_OK</code>) causes two things:
 <ul>
 <li>the <code>cql_error_trace()</code> macro is invoked (this macro typically expands to nothing)</li>
-<li>the code stops what it’s doing and runs the cleanup code via <code>goto cql_cleanup;</code></li>
+<li>the code is redirected to the cleanup block via <code>goto cql_cleanup;</code></li>
 </ul></li>
 </ul>
 <p>The essential sequence is this one:</p>
-<div class="sourceCode" id="cb129"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb129-1"><a href="#cb129-1" aria-hidden="true" tabindex="-1"></a> <span class="cf">if</span> <span class="op">(</span>_rc_ <span class="op">!=</span> SQLITE_OK<span class="op">)</span> <span class="op">{</span> cql_error_trace<span class="op">();</span> <span class="cf">goto</span> cql_cleanup<span class="op">;</span> <span class="op">}</span></span></code></pre></div>
-<p>The C code generator uses this pattern all over to check if anything went wrong and to exit with an error code. Extensive logging can be very expensive but in debug builds, it’s quite normal for <code>cql_error_trace</code> to expand into something like <code>fprintf(stderr, "error %d in %s %s:%d\n", _rc_, _PROC_, __FILE__, __LINE_)</code> which probably a lot more logging than you want in a production build but great if you’re debugging. Recall that CQL generates <code>#define _PROC_ "p"</code> before every procedure.</p>
-<p>This pattern generalizes well and indeed if we use the exception handling pattern, we get a lot of control. Let’s generalize this a tiny bit.</p>
-<div class="sourceCode" id="cb130"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb130-1"><a href="#cb130-1" aria-hidden="true" tabindex="-1"></a><span class="kw">CREATE</span> PROC p (<span class="kw">OUT</span> success BOOL <span class="kw">NOT</span> <span class="kw">NULL</span>)</span>
-<span id="cb130-2"><a href="#cb130-2" aria-hidden="true" tabindex="-1"></a><span class="cf">BEGIN</span></span>
-<span id="cb130-3"><a href="#cb130-3" aria-hidden="true" tabindex="-1"></a>  LET arg <span class="op">:=</span> <span class="ot">&quot;test&quot;</span>;</span>
-<span id="cb130-4"><a href="#cb130-4" aria-hidden="true" tabindex="-1"></a>  <span class="cf">BEGIN</span> TRY</span>
-<span id="cb130-5"><a href="#cb130-5" aria-hidden="true" tabindex="-1"></a>    <span class="kw">CALL</span> something_that_might_fail(arg);</span>
-<span id="cb130-6"><a href="#cb130-6" aria-hidden="true" tabindex="-1"></a>    <span class="kw">SET</span> success <span class="op">:=</span> <span class="dv">1</span>;</span>
-<span id="cb130-7"><a href="#cb130-7" aria-hidden="true" tabindex="-1"></a>  <span class="cf">END</span> TRY;</span>
-<span id="cb130-8"><a href="#cb130-8" aria-hidden="true" tabindex="-1"></a>  <span class="cf">BEGIN</span> CATCH</span>
-<span id="cb130-9"><a href="#cb130-9" aria-hidden="true" tabindex="-1"></a>    <span class="kw">SET</span> success <span class="op">:=</span> <span class="dv">0</span>;</span>
-<span id="cb130-10"><a href="#cb130-10" aria-hidden="true" tabindex="-1"></a>  <span class="cf">END</span> CATCH;</span>
-<span id="cb130-11"><a href="#cb130-11" aria-hidden="true" tabindex="-1"></a><span class="cf">END</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb133"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb133-1"><a href="#cb133-1" aria-hidden="true" tabindex="-1"></a> <span class="cf">if</span> <span class="op">(</span>_rc_ <span class="op">!=</span> SQLITE_OK<span class="op">)</span> <span class="op">{</span> cql_error_trace<span class="op">();</span> <span class="cf">goto</span> cql_cleanup<span class="op">;</span> <span class="op">}</span></span></code></pre></div>
+<p>The C code generator consistently uses this pattern to check if anything went wrong and to exit with an error code. Extensive logging can be very expensive, but in debug builds it’s quite normal for <code>cql_error_trace</code> to expand into something like <code>fprintf(stderr, "error %d in %s %s:%d\n", _rc_, _PROC_, __FILE__, __LINE_)</code> which is probably a lot more logging than you want in a production build but great if you’re debugging. Recall that CQL generates something like <code>#define _PROC_ "p"</code> before every procedure.</p>
+<p>This error pattern generalizes well and indeed if we use the exception handling pattern, we get a lot of control. Let’s generalize this example a tiny bit:</p>
+<div class="sourceCode" id="cb134"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb134-1"><a href="#cb134-1" aria-hidden="true" tabindex="-1"></a><span class="kw">CREATE</span> PROC p (<span class="kw">OUT</span> success BOOL <span class="kw">NOT</span> <span class="kw">NULL</span>)</span>
+<span id="cb134-2"><a href="#cb134-2" aria-hidden="true" tabindex="-1"></a><span class="cf">BEGIN</span></span>
+<span id="cb134-3"><a href="#cb134-3" aria-hidden="true" tabindex="-1"></a>  LET arg <span class="op">:=</span> <span class="ot">&quot;test&quot;</span>;</span>
+<span id="cb134-4"><a href="#cb134-4" aria-hidden="true" tabindex="-1"></a>  <span class="cf">BEGIN</span> TRY</span>
+<span id="cb134-5"><a href="#cb134-5" aria-hidden="true" tabindex="-1"></a>    <span class="kw">CALL</span> something_that_might_fail(arg);</span>
+<span id="cb134-6"><a href="#cb134-6" aria-hidden="true" tabindex="-1"></a>    <span class="kw">SET</span> success <span class="op">:=</span> <span class="dv">1</span>;</span>
+<span id="cb134-7"><a href="#cb134-7" aria-hidden="true" tabindex="-1"></a>  <span class="cf">END</span> TRY;</span>
+<span id="cb134-8"><a href="#cb134-8" aria-hidden="true" tabindex="-1"></a>  <span class="cf">BEGIN</span> CATCH</span>
+<span id="cb134-9"><a href="#cb134-9" aria-hidden="true" tabindex="-1"></a>    <span class="kw">SET</span> success <span class="op">:=</span> <span class="dv">0</span>;</span>
+<span id="cb134-10"><a href="#cb134-10" aria-hidden="true" tabindex="-1"></a>  <span class="cf">END</span> CATCH;</span>
+<span id="cb134-11"><a href="#cb134-11" aria-hidden="true" tabindex="-1"></a><span class="cf">END</span>;</span></code></pre></div>
 <p>CQL doesn’t have complicated exception objects or anything like that, exceptions are just simple control flow. Here’s the code for the above:</p>
-<div class="sourceCode" id="cb131"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb131-1"><a href="#cb131-1" aria-hidden="true" tabindex="-1"></a>CQL_WARN_UNUSED cql_code p<span class="op">(</span>sqlite3 <span class="op">*</span>_Nonnull _db_<span class="op">,</span> cql_bool <span class="op">*</span>_Nonnull success<span class="op">)</span> <span class="op">{</span></span>
-<span id="cb131-2"><a href="#cb131-2" aria-hidden="true" tabindex="-1"></a>  cql_contract_argument_notnull<span class="op">((</span><span class="dt">void</span> <span class="op">*)</span>success<span class="op">,</span> <span class="dv">1</span><span class="op">);</span></span>
-<span id="cb131-3"><a href="#cb131-3" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb131-4"><a href="#cb131-4" aria-hidden="true" tabindex="-1"></a>  cql_code _rc_ <span class="op">=</span> SQLITE_OK<span class="op">;</span></span>
-<span id="cb131-5"><a href="#cb131-5" aria-hidden="true" tabindex="-1"></a>  cql_string_ref arg <span class="op">=</span> NULL<span class="op">;</span></span>
-<span id="cb131-6"><a href="#cb131-6" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb131-7"><a href="#cb131-7" aria-hidden="true" tabindex="-1"></a>  <span class="op">*</span>success <span class="op">=</span> <span class="dv">0</span><span class="op">;</span> <span class="co">// set out arg to non-garbage</span></span>
-<span id="cb131-8"><a href="#cb131-8" aria-hidden="true" tabindex="-1"></a>  cql_set_string_ref<span class="op">(&amp;</span>arg<span class="op">,</span> _literal_1_test_p<span class="op">);</span></span>
-<span id="cb131-9"><a href="#cb131-9" aria-hidden="true" tabindex="-1"></a>  <span class="co">// try</span></span>
-<span id="cb131-10"><a href="#cb131-10" aria-hidden="true" tabindex="-1"></a>  <span class="op">{</span></span>
-<span id="cb131-11"><a href="#cb131-11" aria-hidden="true" tabindex="-1"></a>    _rc_ <span class="op">=</span> something_that_might_fail<span class="op">(</span>_db_<span class="op">,</span> arg<span class="op">);</span></span>
-<span id="cb131-12"><a href="#cb131-12" aria-hidden="true" tabindex="-1"></a>    <span class="cf">if</span> <span class="op">(</span>_rc_ <span class="op">!=</span> SQLITE_OK<span class="op">)</span> <span class="op">{</span> cql_error_trace<span class="op">();</span> <span class="cf">goto</span> catch_start_1<span class="op">;</span> <span class="op">}</span></span>
-<span id="cb131-13"><a href="#cb131-13" aria-hidden="true" tabindex="-1"></a>    <span class="op">*</span>success <span class="op">=</span> <span class="dv">1</span><span class="op">;</span></span>
-<span id="cb131-14"><a href="#cb131-14" aria-hidden="true" tabindex="-1"></a>    <span class="cf">goto</span> catch_end_1<span class="op">;</span></span>
-<span id="cb131-15"><a href="#cb131-15" aria-hidden="true" tabindex="-1"></a>  <span class="op">}</span></span>
-<span id="cb131-16"><a href="#cb131-16" aria-hidden="true" tabindex="-1"></a>  catch_start_1<span class="op">:</span> <span class="op">{</span></span>
-<span id="cb131-17"><a href="#cb131-17" aria-hidden="true" tabindex="-1"></a>    <span class="op">*</span>success <span class="op">=</span> <span class="dv">0</span><span class="op">;</span></span>
-<span id="cb131-18"><a href="#cb131-18" aria-hidden="true" tabindex="-1"></a>  <span class="op">}</span></span>
-<span id="cb131-19"><a href="#cb131-19" aria-hidden="true" tabindex="-1"></a>  catch_end_1<span class="op">:;</span></span>
-<span id="cb131-20"><a href="#cb131-20" aria-hidden="true" tabindex="-1"></a>  _rc_ <span class="op">=</span> SQLITE_OK<span class="op">;</span></span>
-<span id="cb131-21"><a href="#cb131-21" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb131-22"><a href="#cb131-22" aria-hidden="true" tabindex="-1"></a>  cql_string_release<span class="op">(</span>arg<span class="op">);</span></span>
-<span id="cb131-23"><a href="#cb131-23" aria-hidden="true" tabindex="-1"></a>  <span class="cf">return</span> _rc_<span class="op">;</span></span>
-<span id="cb131-24"><a href="#cb131-24" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span></code></pre></div>
-<p>The code is nearly the same. Let’s look at the essential differences:</p>
+<div class="sourceCode" id="cb135"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb135-1"><a href="#cb135-1" aria-hidden="true" tabindex="-1"></a>CQL_WARN_UNUSED cql_code p<span class="op">(</span>sqlite3 <span class="op">*</span>_Nonnull _db_<span class="op">,</span> cql_bool <span class="op">*</span>_Nonnull success<span class="op">)</span> <span class="op">{</span></span>
+<span id="cb135-2"><a href="#cb135-2" aria-hidden="true" tabindex="-1"></a>  cql_contract_argument_notnull<span class="op">((</span><span class="dt">void</span> <span class="op">*)</span>success<span class="op">,</span> <span class="dv">1</span><span class="op">);</span></span>
+<span id="cb135-3"><a href="#cb135-3" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb135-4"><a href="#cb135-4" aria-hidden="true" tabindex="-1"></a>  cql_code _rc_ <span class="op">=</span> SQLITE_OK<span class="op">;</span></span>
+<span id="cb135-5"><a href="#cb135-5" aria-hidden="true" tabindex="-1"></a>  cql_string_ref arg <span class="op">=</span> NULL<span class="op">;</span></span>
+<span id="cb135-6"><a href="#cb135-6" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb135-7"><a href="#cb135-7" aria-hidden="true" tabindex="-1"></a>  <span class="op">*</span>success <span class="op">=</span> <span class="dv">0</span><span class="op">;</span> <span class="co">// set out arg to non-garbage</span></span>
+<span id="cb135-8"><a href="#cb135-8" aria-hidden="true" tabindex="-1"></a>  cql_set_string_ref<span class="op">(&amp;</span>arg<span class="op">,</span> _literal_1_test_p<span class="op">);</span></span>
+<span id="cb135-9"><a href="#cb135-9" aria-hidden="true" tabindex="-1"></a>  <span class="co">// try</span></span>
+<span id="cb135-10"><a href="#cb135-10" aria-hidden="true" tabindex="-1"></a>  <span class="op">{</span></span>
+<span id="cb135-11"><a href="#cb135-11" aria-hidden="true" tabindex="-1"></a>    _rc_ <span class="op">=</span> something_that_might_fail<span class="op">(</span>_db_<span class="op">,</span> arg<span class="op">);</span></span>
+<span id="cb135-12"><a href="#cb135-12" aria-hidden="true" tabindex="-1"></a>    <span class="cf">if</span> <span class="op">(</span>_rc_ <span class="op">!=</span> SQLITE_OK<span class="op">)</span> <span class="op">{</span> cql_error_trace<span class="op">();</span> <span class="cf">goto</span> catch_start_1<span class="op">;</span> <span class="op">}</span></span>
+<span id="cb135-13"><a href="#cb135-13" aria-hidden="true" tabindex="-1"></a>    <span class="op">*</span>success <span class="op">=</span> <span class="dv">1</span><span class="op">;</span></span>
+<span id="cb135-14"><a href="#cb135-14" aria-hidden="true" tabindex="-1"></a>    <span class="cf">goto</span> catch_end_1<span class="op">;</span></span>
+<span id="cb135-15"><a href="#cb135-15" aria-hidden="true" tabindex="-1"></a>  <span class="op">}</span></span>
+<span id="cb135-16"><a href="#cb135-16" aria-hidden="true" tabindex="-1"></a>  catch_start_1<span class="op">:</span> <span class="op">{</span></span>
+<span id="cb135-17"><a href="#cb135-17" aria-hidden="true" tabindex="-1"></a>    <span class="op">*</span>success <span class="op">=</span> <span class="dv">0</span><span class="op">;</span></span>
+<span id="cb135-18"><a href="#cb135-18" aria-hidden="true" tabindex="-1"></a>  <span class="op">}</span></span>
+<span id="cb135-19"><a href="#cb135-19" aria-hidden="true" tabindex="-1"></a>  catch_end_1<span class="op">:;</span></span>
+<span id="cb135-20"><a href="#cb135-20" aria-hidden="true" tabindex="-1"></a>  _rc_ <span class="op">=</span> SQLITE_OK<span class="op">;</span></span>
+<span id="cb135-21"><a href="#cb135-21" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb135-22"><a href="#cb135-22" aria-hidden="true" tabindex="-1"></a>  cql_string_release<span class="op">(</span>arg<span class="op">);</span></span>
+<span id="cb135-23"><a href="#cb135-23" aria-hidden="true" tabindex="-1"></a>  <span class="cf">return</span> _rc_<span class="op">;</span></span>
+<span id="cb135-24"><a href="#cb135-24" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span></code></pre></div>
+<p>The code in this case is nearly the same as the previous example. Let’s look at the essential differences:</p>
 <ul>
-<li>If there is an error, the code hits <code>goto catch_start_1</code></li>
-<li>If the try block succeeds, the code hits <code>goto catch_end_1</code></li>
-<li>both branches set the <code>success</code> out parameter</li>
-<li>we added that out argument, CQL generated an error check to ensure that arg 1 is not null
+<li>If there is an error, <code>goto catch_start_1</code> will run</li>
+<li>If the try block succeeds, <code>goto catch_end_1</code> will run</li>
+<li>both the <code>TRY</code> and <code>CATCH</code> branches set the <code>success</code> out parameter</li>
+<li>since an out argument was added, CQL generated an error check to ensure that <code>success</code> is not null
 <ul>
-<li><code>cql_contract_argument_notnull((void *)success, 1)</code>, the 1 means arg 1</li>
-<li>the hidden <code>_db_</code> arg doesn’t count</li>
+<li><code>cql_contract_argument_notnull((void *)success, 1)</code>, the 1 means “argument 1” and will appear in the error message if this test fails</li>
+<li>the hidden <code>_db_</code> argument doesn’t count for error message purposes, so <code>success</code> is still the first argument</li>
 </ul></li>
 </ul>
-<p>How does this happen? <code>cg_trycatch_helper</code></p>
-<div class="sourceCode" id="cb132"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb132-1"><a href="#cb132-1" aria-hidden="true" tabindex="-1"></a><span class="co">// Very little magic is needed to do try/catch in our context.  The error</span></span>
-<span id="cb132-2"><a href="#cb132-2" aria-hidden="true" tabindex="-1"></a><span class="co">// handlers for all the sqlite calls check _rc_ and if it&#39;s an error they</span></span>
-<span id="cb132-3"><a href="#cb132-3" aria-hidden="true" tabindex="-1"></a><span class="co">// &quot;goto&quot; the current error target.  That target is usually CQL_CLEANUP_DEFAULT_LABEL.</span></span>
-<span id="cb132-4"><a href="#cb132-4" aria-hidden="true" tabindex="-1"></a><span class="co">// Inside the try block, the cleanup handler is changed to the catch block.</span></span>
-<span id="cb132-5"><a href="#cb132-5" aria-hidden="true" tabindex="-1"></a><span class="co">// The catch block puts it back.  Otherwise, generate nested statements as usual.</span></span>
-<span id="cb132-6"><a href="#cb132-6" aria-hidden="true" tabindex="-1"></a><span class="dt">static</span> <span class="dt">void</span> cg_trycatch_helper<span class="op">(</span>ast_node <span class="op">*</span>try_list<span class="op">,</span> ast_node <span class="op">*</span>try_extras<span class="op">,</span> ast_node <span class="op">*</span>catch_list<span class="op">)</span> <span class="op">{</span></span>
-<span id="cb132-7"><a href="#cb132-7" aria-hidden="true" tabindex="-1"></a>  CHARBUF_OPEN<span class="op">(</span>catch_start<span class="op">);</span></span>
-<span id="cb132-8"><a href="#cb132-8" aria-hidden="true" tabindex="-1"></a>  CHARBUF_OPEN<span class="op">(</span>catch_end<span class="op">);</span></span>
-<span id="cb132-9"><a href="#cb132-9" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb132-10"><a href="#cb132-10" aria-hidden="true" tabindex="-1"></a>  <span class="co">// We need unique labels for this block</span></span>
-<span id="cb132-11"><a href="#cb132-11" aria-hidden="true" tabindex="-1"></a>  <span class="op">++</span>catch_block_count<span class="op">;</span></span>
-<span id="cb132-12"><a href="#cb132-12" aria-hidden="true" tabindex="-1"></a>  bprintf<span class="op">(&amp;</span>catch_start<span class="op">,</span> <span class="st">&quot;catch_start_%d&quot;</span><span class="op">,</span> catch_block_count<span class="op">);</span></span>
-<span id="cb132-13"><a href="#cb132-13" aria-hidden="true" tabindex="-1"></a>  bprintf<span class="op">(&amp;</span>catch_end<span class="op">,</span> <span class="st">&quot;catch_end_%d&quot;</span><span class="op">,</span> catch_block_count<span class="op">);</span></span>
-<span id="cb132-14"><a href="#cb132-14" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb132-15"><a href="#cb132-15" aria-hidden="true" tabindex="-1"></a>  <span class="co">// Divert the error target.</span></span>
-<span id="cb132-16"><a href="#cb132-16" aria-hidden="true" tabindex="-1"></a>  CSTR saved_error_target <span class="op">=</span> error_target<span class="op">;</span></span>
-<span id="cb132-17"><a href="#cb132-17" aria-hidden="true" tabindex="-1"></a>  bool_t saved_error_target_used <span class="op">=</span> error_target_used<span class="op">;</span></span>
-<span id="cb132-18"><a href="#cb132-18" aria-hidden="true" tabindex="-1"></a>  error_target <span class="op">=</span> catch_start<span class="op">.</span>ptr<span class="op">;</span></span>
-<span id="cb132-19"><a href="#cb132-19" aria-hidden="true" tabindex="-1"></a>  error_target_used <span class="op">=</span> <span class="dv">0</span><span class="op">;</span></span>
-<span id="cb132-20"><a href="#cb132-20" aria-hidden="true" tabindex="-1"></a> <span class="op">...</span></span></code></pre></div>
-<p>All of the error handling does goto <code>error_target</code> whatever that is. The try/catch pattern simply changes the current error target. The rest of the code is just to save the current error target and to create unique labels for the the control flow.</p>
+<p>How does this happen? Let’s look at <code>cg_trycatch_helper</code> which does this work:</p>
+<div class="sourceCode" id="cb136"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb136-1"><a href="#cb136-1" aria-hidden="true" tabindex="-1"></a><span class="co">// Very little magic is needed to do try/catch in our context.  The error</span></span>
+<span id="cb136-2"><a href="#cb136-2" aria-hidden="true" tabindex="-1"></a><span class="co">// handlers for all the sqlite calls check _rc_ and if it&#39;s an error they</span></span>
+<span id="cb136-3"><a href="#cb136-3" aria-hidden="true" tabindex="-1"></a><span class="co">// &quot;goto&quot; the current error target.  That target is usually CQL_CLEANUP_DEFAULT_LABEL.</span></span>
+<span id="cb136-4"><a href="#cb136-4" aria-hidden="true" tabindex="-1"></a><span class="co">// Inside the try block, the cleanup handler is changed to the catch block.</span></span>
+<span id="cb136-5"><a href="#cb136-5" aria-hidden="true" tabindex="-1"></a><span class="co">// The catch block puts it back.  Otherwise, generate nested statements as usual.</span></span>
+<span id="cb136-6"><a href="#cb136-6" aria-hidden="true" tabindex="-1"></a><span class="dt">static</span> <span class="dt">void</span> cg_trycatch_helper<span class="op">(</span>ast_node <span class="op">*</span>try_list<span class="op">,</span> ast_node <span class="op">*</span>try_extras<span class="op">,</span> ast_node <span class="op">*</span>catch_list<span class="op">)</span> <span class="op">{</span></span>
+<span id="cb136-7"><a href="#cb136-7" aria-hidden="true" tabindex="-1"></a>  CHARBUF_OPEN<span class="op">(</span>catch_start<span class="op">);</span></span>
+<span id="cb136-8"><a href="#cb136-8" aria-hidden="true" tabindex="-1"></a>  CHARBUF_OPEN<span class="op">(</span>catch_end<span class="op">);</span></span>
+<span id="cb136-9"><a href="#cb136-9" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb136-10"><a href="#cb136-10" aria-hidden="true" tabindex="-1"></a>  <span class="co">// We need unique labels for this block</span></span>
+<span id="cb136-11"><a href="#cb136-11" aria-hidden="true" tabindex="-1"></a>  <span class="op">++</span>catch_block_count<span class="op">;</span></span>
+<span id="cb136-12"><a href="#cb136-12" aria-hidden="true" tabindex="-1"></a>  bprintf<span class="op">(&amp;</span>catch_start<span class="op">,</span> <span class="st">&quot;catch_start_%d&quot;</span><span class="op">,</span> catch_block_count<span class="op">);</span></span>
+<span id="cb136-13"><a href="#cb136-13" aria-hidden="true" tabindex="-1"></a>  bprintf<span class="op">(&amp;</span>catch_end<span class="op">,</span> <span class="st">&quot;catch_end_%d&quot;</span><span class="op">,</span> catch_block_count<span class="op">);</span></span>
+<span id="cb136-14"><a href="#cb136-14" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb136-15"><a href="#cb136-15" aria-hidden="true" tabindex="-1"></a>  <span class="co">// Divert the error target.</span></span>
+<span id="cb136-16"><a href="#cb136-16" aria-hidden="true" tabindex="-1"></a>  CSTR saved_error_target <span class="op">=</span> error_target<span class="op">;</span></span>
+<span id="cb136-17"><a href="#cb136-17" aria-hidden="true" tabindex="-1"></a>  bool_t saved_error_target_used <span class="op">=</span> error_target_used<span class="op">;</span></span>
+<span id="cb136-18"><a href="#cb136-18" aria-hidden="true" tabindex="-1"></a>  error_target <span class="op">=</span> catch_start<span class="op">.</span>ptr<span class="op">;</span></span>
+<span id="cb136-19"><a href="#cb136-19" aria-hidden="true" tabindex="-1"></a>  error_target_used <span class="op">=</span> <span class="dv">0</span><span class="op">;</span></span>
+<span id="cb136-20"><a href="#cb136-20" aria-hidden="true" tabindex="-1"></a> <span class="op">...</span></span></code></pre></div>
+<p>The secret is the <code>error_target</code> global variable. All of the error handling will emit a goto <code>error_target</code> statement. The try/catch pattern simply changes the current error target. The rest of the code in the helper is just to save the current error target and to create unique labels for the try/catch block.</p>
 <p>The important notion is that, if anything goes wrong, whatever it is, the generator simply does a <code>goto error_target</code> and that will either hit the catch block or else go to cleanup.</p>
 <p>The <code>THROW</code> operation illustrates this well:</p>
-<div class="sourceCode" id="cb133"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb133-1"><a href="#cb133-1" aria-hidden="true" tabindex="-1"></a><span class="co">// Convert _rc_ into an error code.  If it already is one keep it.</span></span>
-<span id="cb133-2"><a href="#cb133-2" aria-hidden="true" tabindex="-1"></a><span class="co">// Then go to the current error target.</span></span>
-<span id="cb133-3"><a href="#cb133-3" aria-hidden="true" tabindex="-1"></a><span class="dt">static</span> <span class="dt">void</span> cg_throw_stmt<span class="op">(</span>ast_node <span class="op">*</span>ast<span class="op">)</span> <span class="op">{</span></span>
-<span id="cb133-4"><a href="#cb133-4" aria-hidden="true" tabindex="-1"></a>  Contract<span class="op">(</span>is_ast_throw_stmt<span class="op">(</span>ast<span class="op">));</span></span>
-<span id="cb133-5"><a href="#cb133-5" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb133-6"><a href="#cb133-6" aria-hidden="true" tabindex="-1"></a>  bprintf<span class="op">(</span>cg_main_output<span class="op">,</span> <span class="st">&quot;_rc_ = cql_best_error(%s);</span><span class="sc">\n</span><span class="st">&quot;</span><span class="op">,</span> rcthrown_current<span class="op">);</span></span>
-<span id="cb133-7"><a href="#cb133-7" aria-hidden="true" tabindex="-1"></a>  bprintf<span class="op">(</span>cg_main_output<span class="op">,</span> <span class="st">&quot;goto %s;</span><span class="sc">\n</span><span class="st">&quot;</span><span class="op">,</span> error_target<span class="op">);</span></span>
-<span id="cb133-8"><a href="#cb133-8" aria-hidden="true" tabindex="-1"></a>  error_target_used <span class="op">=</span> <span class="dv">1</span><span class="op">;</span></span>
-<span id="cb133-9"><a href="#cb133-9" aria-hidden="true" tabindex="-1"></a>  rcthrown_used <span class="op">=</span> <span class="dv">1</span><span class="op">;</span></span>
-<span id="cb133-10"><a href="#cb133-10" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span></code></pre></div>
+<div class="sourceCode" id="cb137"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb137-1"><a href="#cb137-1" aria-hidden="true" tabindex="-1"></a><span class="co">// Convert _rc_ into an error code.  If it already is one keep it.</span></span>
+<span id="cb137-2"><a href="#cb137-2" aria-hidden="true" tabindex="-1"></a><span class="co">// Then go to the current error target.</span></span>
+<span id="cb137-3"><a href="#cb137-3" aria-hidden="true" tabindex="-1"></a><span class="dt">static</span> <span class="dt">void</span> cg_throw_stmt<span class="op">(</span>ast_node <span class="op">*</span>ast<span class="op">)</span> <span class="op">{</span></span>
+<span id="cb137-4"><a href="#cb137-4" aria-hidden="true" tabindex="-1"></a>  Contract<span class="op">(</span>is_ast_throw_stmt<span class="op">(</span>ast<span class="op">));</span></span>
+<span id="cb137-5"><a href="#cb137-5" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb137-6"><a href="#cb137-6" aria-hidden="true" tabindex="-1"></a>  bprintf<span class="op">(</span>cg_main_output<span class="op">,</span> <span class="st">&quot;_rc_ = cql_best_error(%s);</span><span class="sc">\n</span><span class="st">&quot;</span><span class="op">,</span> rcthrown_current<span class="op">);</span></span>
+<span id="cb137-7"><a href="#cb137-7" aria-hidden="true" tabindex="-1"></a>  bprintf<span class="op">(</span>cg_main_output<span class="op">,</span> <span class="st">&quot;goto %s;</span><span class="sc">\n</span><span class="st">&quot;</span><span class="op">,</span> error_target<span class="op">);</span></span>
+<span id="cb137-8"><a href="#cb137-8" aria-hidden="true" tabindex="-1"></a>  error_target_used <span class="op">=</span> <span class="dv">1</span><span class="op">;</span></span>
+<span id="cb137-9"><a href="#cb137-9" aria-hidden="true" tabindex="-1"></a>  rcthrown_used <span class="op">=</span> <span class="dv">1</span><span class="op">;</span></span>
+<span id="cb137-10"><a href="#cb137-10" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span></code></pre></div>
 <ul>
-<li>first we make sure <em>rc</em> has some kind of error in it either <code>rcthrown_current</code> or else <code>SQLITE_ERROR</code></li>
-<li>then we goto the current error target</li>
-<li><code>error_target_used</code> tracks whether there were any possible errors, this is just to avoid C compiler errors about unused labels.
+<li>first we make sure <code>_rc_</code> has some kind of error in it, either <code>rcthrown_current</code> or else <code>SQLITE_ERROR</code></li>
+<li>then we go to the current error target</li>
+<li><code>error_target_used</code> tracks whether if the error label was used, this is just to avoid C compiler errors about unused labels.
 <ul>
 <li>if the label is not used it won’t be emitted</li>
-<li>the code never jump back to an error label so we’ll always know if it was used before we need to emit it</li>
+<li>the code never jumps back to an error label, so we’ll always know if the label was used before we need to emit it</li>
 </ul></li>
 </ul>
-<p>Note: every catch block captures the value of <code>_rc_</code> in a local variable whose name is in <code>rcthrown_current</code>. This is the current failing result code accessible by <code>@RC</code> in CQL.</p>
+<p>Note: every catch block captures the value of <code>_rc_</code> in a local variable whose name is in <code>rcthrown_current</code>. This captured value is the current failing result code accessible by <code>@RC</code> in CQL.</p>
 <p>A catch block can therefore do stuff like:</p>
-<div class="sourceCode" id="cb134"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb134-1"><a href="#cb134-1" aria-hidden="true" tabindex="-1"></a><span class="cf">IF</span> @RC <span class="op">=</span> <span class="dv">1</span> <span class="cf">THEN</span></span>
-<span id="cb134-2"><a href="#cb134-2" aria-hidden="true" tabindex="-1"></a>  THROW;</span>
-<span id="cb134-3"><a href="#cb134-3" aria-hidden="true" tabindex="-1"></a><span class="cf">ELSE</span></span>
-<span id="cb134-4"><a href="#cb134-4" aria-hidden="true" tabindex="-1"></a>  <span class="kw">call</span> attempt_retry();</span>
-<span id="cb134-5"><a href="#cb134-5" aria-hidden="true" tabindex="-1"></a><span class="cf">END</span> <span class="cf">IF</span>;</span></code></pre></div>
-<p>or something like that.</p>
-<p>This entire mechanism is built with basically just a few state variables that nest. There is no complicated stack walking or anything like that. All the code has to do is chain the error labels together and let users create new catch blocks with new error labels. All that together gives you very flexible try/catch behaviour.</p>
+<div class="sourceCode" id="cb138"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb138-1"><a href="#cb138-1" aria-hidden="true" tabindex="-1"></a><span class="cf">IF</span> @RC <span class="op">=</span> <span class="dv">1</span> <span class="cf">THEN</span></span>
+<span id="cb138-2"><a href="#cb138-2" aria-hidden="true" tabindex="-1"></a>  THROW;</span>
+<span id="cb138-3"><a href="#cb138-3" aria-hidden="true" tabindex="-1"></a><span class="cf">ELSE</span></span>
+<span id="cb138-4"><a href="#cb138-4" aria-hidden="true" tabindex="-1"></a>  <span class="kw">call</span> attempt_retry();</span>
+<span id="cb138-5"><a href="#cb138-5" aria-hidden="true" tabindex="-1"></a><span class="cf">END</span> <span class="cf">IF</span>;</span></code></pre></div>
+<p>This entire mechanism is built with basically just a few state variables that nest. There is no complicated stack walking or anything like that. All the code has to do is chain the error labels together and let users create new catch blocks with new error labels. All that together gives you very flexible try/catch behaviour with very little overhead.</p>
+<h3 id="string-literals">String Literals</h3>
+<p>Before we move on to more complex statements we have to discuss string literals a little bit. We’ve mentioned before that the compiler is going to generate something like this:</p>
+<div class="sourceCode" id="cb139"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb139-1"><a href="#cb139-1" aria-hidden="true" tabindex="-1"></a>cql_string_literal<span class="op">(</span>_literal_1_test_p<span class="op">,</span> <span class="st">&quot;test&quot;</span><span class="op">);</span></span></code></pre></div>
+<p>To create a reference counted object <code>_literal_1_test_p</code> that it can use. Now we’re going to talk about how the text <code>"test"</code> was created and how that gets more complicated.</p>
+<p>The first thing to remember is that the generator creates C programs. That means no matter what kind of literal we might be processing it’s ending up encoded as a C string for the C compiler. The C compiler will be the first thing the decodes the text the generator produces and puts the byte we need into the final programs data segment or whereever. That means if we have SQL format strings that need to go to SQLite they will be twice-encoded, the SQL string is escaped as needed for SQLite and <em>that</em> is escaped again for the C compiler.</p>
+<p>An example might make this clearer consider the following SQL:</p>
+<div class="sourceCode" id="cb140"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb140-1"><a href="#cb140-1" aria-hidden="true" tabindex="-1"></a>  <span class="kw">SELECT</span> <span class="st">&#39;&quot;x</span><span class="ch">&#39;&#39;</span><span class="st">y&quot;&#39;</span> <span class="kw">AS</span> a, <span class="ot">&quot;&#39;y&#39;\n&quot;</span> <span class="kw">AS</span> b;</span></code></pre></div>
+<p>The generated text for this statement will be:</p>
+<div class="sourceCode" id="cb141"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb141-1"><a href="#cb141-1" aria-hidden="true" tabindex="-1"></a>  <span class="st">&quot;SELECT &#39;</span><span class="sc">\&quot;</span><span class="st">x&#39;&#39;y</span><span class="sc">\&quot;</span><span class="st">&#39;, &#39;&#39;&#39;y&#39;&#39;</span><span class="sc">\n</span><span class="st">&#39;&quot;</span></span></code></pre></div>
+<p>Let’s review that in some detail:</p>
+<ul>
+<li>the first string “a” is a standard SQL string
+<ul>
+<li>it is represented unchanged in the AST, it is <em>not</em> unescaped</li>
+<li>even the outer single quotes are preserved, CQL has no need to change it at all</li>
+<li>when we emit it into our output it will be read by the C compiler, so</li>
+<li>at that time it is escaped <em>again</em> into C format
+<ul>
+<li>the double quotes which required no escaping in SQL become <code>\"</code></li>
+</ul></li>
+<li>the single quote character requires no escape but there are still two of them because SQLite will also process this string</li>
+</ul></li>
+<li>the second string “b” is a C formatted string literal
+<ul>
+<li>SQLite doesn’t support this format or its escapes, therefore</li>
+<li>as discussed in <a href="https://cgsql.dev/cql-guide/int01">Part 1</a>, it is decoded to plain text, then re-encoded as a SQL escaped string</li>
+<li>internal newlines do not require escaping in SQL, they are in the string as the newline character not ‘’ or anything like that
+<ul>
+<li>to be completely precise the byte value 0x0a is in the string unescaped</li>
+</ul></li>
+<li>internal single quotes don’t require escaping in C, these have to be doubled in a SQL string</li>
+<li>the outer double quotes are removed and replaced by single quoates during this process</li>
+<li>the AST now has a valid SQL formatted string possibly with weird characters in it</li>
+<li>as before, this string has to be formatted for the C compiler so now it has to be escaped again</li>
+<li>the single quotes require no further processing, though now there are quite a few of them</li>
+<li>the embedded newline is converted to the escape sequence “” so we’re back to sort of where we started
+<ul>
+<li>the C compiler will convert this back to the byte 0x0a which is what ends up in the data segment</li>
+</ul></li>
+</ul></li>
+</ul>
+<p>In the above example we were making one overall string for the <code>SELECT</code> statement so the outer double quotes are around the whole statement. That was just for the convenience of this example. If the literals had been in some other loose context then individual strings would be produced the same way. Except, not so fast, not every string literal is heading for SQLite. Some are just making regular strings. In that case even if they are destined for SQLite they will go as bound arguments to a statement not in the text of the SQL. That means <em>those</em> strings do not need SQL escaping.</p>
+<p>Consider:</p>
+<div class="sourceCode" id="cb142"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb142-1"><a href="#cb142-1" aria-hidden="true" tabindex="-1"></a>  LET a <span class="op">:=</span> <span class="st">&#39;&quot;x</span><span class="ch">&#39;&#39;</span><span class="st">y&quot;&#39;</span>;</span>
+<span id="cb142-2"><a href="#cb142-2" aria-hidden="true" tabindex="-1"></a>  LET b <span class="op">:=</span> <span class="ot">&quot;&#39;y&#39;\n&quot;</span>;</span></code></pre></div>
+<p>To do those assignments we need:</p>
+<div class="sourceCode" id="cb143"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb143-1"><a href="#cb143-1" aria-hidden="true" tabindex="-1"></a>cql_string_literal<span class="op">(</span>_literal_1_x_y_p<span class="op">,</span> <span class="st">&quot;</span><span class="sc">\&quot;</span><span class="st">x&#39;y</span><span class="sc">\&quot;</span><span class="st">&quot;</span><span class="op">);</span></span>
+<span id="cb143-2"><a href="#cb143-2" aria-hidden="true" tabindex="-1"></a>cql_string_literal<span class="op">(</span>_literal_2_y_p<span class="op">,</span> <span class="st">&quot;&#39;y&#39;</span><span class="sc">\n</span><span class="st">&quot;</span><span class="op">);</span></span></code></pre></div>
+<p>In both of these cases the steps are:</p>
+<ul>
+<li>unescape the escaped SQL string in the AST to plain text
+<ul>
+<li>removing the outer single quotes of course</li>
+</ul></li>
+<li>re-escape the plain text (which might include newlines and such) as a C string
+<ul>
+<li>emit that text, including its outer double quotes</li>
+</ul></li>
+</ul>
+<p>Trivia: the name of the string literal variables include a fragment of the string to make them a little easier to spot.</p>
+<p><code>encoders.h</code> has the encoding functions * <code>cg_decode_string_literal</code> * <code>cg_encode_string_literal</code> * <code>cg_encode_c_string_literal</code> * <code>cg_decode_c_string_literal</code></p>
+<p>As well as similar functions for single characters to make all this possible. Pretty much every combination of encoding and re-encoding happens in some path through the code generator.</p>
+<h3 id="executing-sqlite-statements">Executing SQLite Statements</h3>
+<p>By way of example let’s consider a pretty simple piece of SQL we might want to run.</p>
+<div class="sourceCode" id="cb144"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb144-1"><a href="#cb144-1" aria-hidden="true" tabindex="-1"></a><span class="kw">CREATE</span> <span class="kw">TABLE</span> foo(<span class="kw">id</span> <span class="dt">INTEGER</span>, t TEXT);</span>
+<span id="cb144-2"><a href="#cb144-2" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb144-3"><a href="#cb144-3" aria-hidden="true" tabindex="-1"></a><span class="kw">CREATE</span> PROC p (id_ <span class="dt">INTEGER</span>, t_ TEXT)</span>
+<span id="cb144-4"><a href="#cb144-4" aria-hidden="true" tabindex="-1"></a><span class="cf">BEGIN</span></span>
+<span id="cb144-5"><a href="#cb144-5" aria-hidden="true" tabindex="-1"></a>  <span class="kw">UPDATE</span> foo</span>
+<span id="cb144-6"><a href="#cb144-6" aria-hidden="true" tabindex="-1"></a>  <span class="kw">SET</span> t <span class="op">=</span> t_</span>
+<span id="cb144-7"><a href="#cb144-7" aria-hidden="true" tabindex="-1"></a>    <span class="kw">WHERE</span> <span class="kw">id</span> <span class="op">=</span> id_;</span>
+<span id="cb144-8"><a href="#cb144-8" aria-hidden="true" tabindex="-1"></a><span class="cf">END</span>;</span></code></pre></div>
+<p>To make this happen we’re going to have to do the following things: * create a string literal with the statement we need * the references to <code>id_</code> and <code>t_</code> have to be replaced with <code>?</code> * we prepare that statement * we bind the values of <code>id_</code> and <code>t_</code> * we <code>step</code> the statement * we <code>finalize</code> the statement * suitable error checks have to be done at each stage</p>
+<p>That’s quite a bit of code and it’s easy to forget a step, this is an area where CQL shines. The code we had to write in CQL was very clear and all the error checking is implicit.</p>
+<p>This is the generated code. We’ll walk through it and discuss how it is created.</p>
+<div class="sourceCode" id="cb145"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb145-1"><a href="#cb145-1" aria-hidden="true" tabindex="-1"></a>CQL_WARN_UNUSED cql_code p<span class="op">(</span></span>
+<span id="cb145-2"><a href="#cb145-2" aria-hidden="true" tabindex="-1"></a>  sqlite3 <span class="op">*</span>_Nonnull _db_<span class="op">,</span></span>
+<span id="cb145-3"><a href="#cb145-3" aria-hidden="true" tabindex="-1"></a>  cql_nullable_int32 id_<span class="op">,</span></span>
+<span id="cb145-4"><a href="#cb145-4" aria-hidden="true" tabindex="-1"></a>  cql_string_ref _Nullable t_<span class="op">)</span></span>
+<span id="cb145-5"><a href="#cb145-5" aria-hidden="true" tabindex="-1"></a><span class="op">{</span></span>
+<span id="cb145-6"><a href="#cb145-6" aria-hidden="true" tabindex="-1"></a>  cql_code _rc_ <span class="op">=</span> SQLITE_OK<span class="op">;</span></span>
+<span id="cb145-7"><a href="#cb145-7" aria-hidden="true" tabindex="-1"></a>  sqlite3_stmt <span class="op">*</span>_temp_stmt <span class="op">=</span> NULL<span class="op">;</span></span>
+<span id="cb145-8"><a href="#cb145-8" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb145-9"><a href="#cb145-9" aria-hidden="true" tabindex="-1"></a>  _rc_ <span class="op">=</span> cql_prepare<span class="op">(</span>_db_<span class="op">,</span> <span class="op">&amp;</span>_temp_stmt<span class="op">,</span></span>
+<span id="cb145-10"><a href="#cb145-10" aria-hidden="true" tabindex="-1"></a>    <span class="st">&quot;UPDATE foo &quot;</span></span>
+<span id="cb145-11"><a href="#cb145-11" aria-hidden="true" tabindex="-1"></a>    <span class="st">&quot;SET t = ? &quot;</span></span>
+<span id="cb145-12"><a href="#cb145-12" aria-hidden="true" tabindex="-1"></a>      <span class="st">&quot;WHERE id = ?&quot;</span><span class="op">);</span></span>
+<span id="cb145-13"><a href="#cb145-13" aria-hidden="true" tabindex="-1"></a>  cql_multibind<span class="op">(&amp;</span>_rc_<span class="op">,</span> _db_<span class="op">,</span> <span class="op">&amp;</span>_temp_stmt<span class="op">,</span> <span class="dv">2</span><span class="op">,</span></span>
+<span id="cb145-14"><a href="#cb145-14" aria-hidden="true" tabindex="-1"></a>                CQL_DATA_TYPE_INT32<span class="op">,</span> <span class="op">&amp;</span>id_<span class="op">,</span></span>
+<span id="cb145-15"><a href="#cb145-15" aria-hidden="true" tabindex="-1"></a>                CQL_DATA_TYPE_STRING<span class="op">,</span> t_<span class="op">);</span></span>
+<span id="cb145-16"><a href="#cb145-16" aria-hidden="true" tabindex="-1"></a>  <span class="cf">if</span> <span class="op">(</span>_rc_ <span class="op">!=</span> SQLITE_OK<span class="op">)</span> <span class="op">{</span> cql_error_trace<span class="op">();</span> <span class="cf">goto</span> cql_cleanup<span class="op">;</span> <span class="op">}</span></span>
+<span id="cb145-17"><a href="#cb145-17" aria-hidden="true" tabindex="-1"></a>  _rc_ <span class="op">=</span> sqlite3_step<span class="op">(</span>_temp_stmt<span class="op">);</span></span>
+<span id="cb145-18"><a href="#cb145-18" aria-hidden="true" tabindex="-1"></a>  <span class="cf">if</span> <span class="op">(</span>_rc_ <span class="op">!=</span> SQLITE_DONE<span class="op">)</span> <span class="op">{</span> cql_error_trace<span class="op">();</span> <span class="cf">goto</span> cql_cleanup<span class="op">;</span> <span class="op">}</span></span>
+<span id="cb145-19"><a href="#cb145-19" aria-hidden="true" tabindex="-1"></a>  cql_finalize_stmt<span class="op">(&amp;</span>_temp_stmt<span class="op">);</span></span>
+<span id="cb145-20"><a href="#cb145-20" aria-hidden="true" tabindex="-1"></a>  _rc_ <span class="op">=</span> SQLITE_OK<span class="op">;</span></span>
+<span id="cb145-21"><a href="#cb145-21" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb145-22"><a href="#cb145-22" aria-hidden="true" tabindex="-1"></a>cql_cleanup<span class="op">:</span></span>
+<span id="cb145-23"><a href="#cb145-23" aria-hidden="true" tabindex="-1"></a>  cql_finalize_stmt<span class="op">(&amp;</span>_temp_stmt<span class="op">);</span></span>
+<span id="cb145-24"><a href="#cb145-24" aria-hidden="true" tabindex="-1"></a>  <span class="cf">return</span> _rc_<span class="op">;</span></span>
+<span id="cb145-25"><a href="#cb145-25" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span></code></pre></div>
+<ul>
+<li>the functions signature includes the hidden <code>_db_</code> parameter plus the two arguments</li>
+<li>we need a hidden <code>_rc_</code> variable to hold the result codes from SQLite</li>
+<li>we need a scratch <code>sqlite3_stmt *</code> named <code>_temp_stmt</code> to talk to SQLite
+<ul>
+<li>when this is created, the cleanup section gets <code>cql_finalize_stmt(&amp;_temp_stmt);</code></li>
+<li><code>cql_finalize_stmt</code> sets the statement to null and does nothing if it’s already null</li>
+</ul></li>
+<li>the string <code>"INSERT INTO foo(id, t) VALUES(?, ?)"</code> is created from the AST
+<ul>
+<li>recall that we have <code>variables_callback</code> as an option, it’s used here to track the variables and replace them with <code>?</code></li>
+<li>more on this shortly</li>
+</ul></li>
+<li><code>cql_multibind</code> is used to bind the values of <code>id_</code> and <code>t_</code>
+<ul>
+<li>this is just a varargs version of the normal SQLite binding functions, it’s only done this way to save space</li>
+<li>only one error check is needed for any binding failure</li>
+<li>the type of binding is encoded very economically</li>
+<li>the “2” here refers to two arguments</li>
+</ul></li>
+<li>the usual error processing happens with <code>cql_error_trace</code> and <code>goto cql_cleanup</code></li>
+<li>the statment is executed with <code>sqlite3_step</code></li>
+<li>temporary statements are finalized immediately with <code>cql_finalize_stmt</code>
+<ul>
+<li>in this case its redundant because the code is going to fall through to cleanup anyway</li>
+<li>in general there could be many statements and we want to finalize immediately</li>
+<li>this is an optimization opportunity, procedures with just one statement are very common</li>
+</ul></li>
+</ul>
+<p>Most of these steps are actually hard coded. There is no variability in the sequence after the <code>multibind</code> call, so that’s just boiler-plate the compiler can inject.</p>
+<p>We don’t want to declare <code>_temp_stmt</code> over and over so there’s a flag that records whether it has already been declared in the current procedure.</p>
+<div class="sourceCode" id="cb146"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb146-1"><a href="#cb146-1" aria-hidden="true" tabindex="-1"></a><span class="co">// Emit a declaration for the temporary statement _temp_stmt_ if we haven&#39;t</span></span>
+<span id="cb146-2"><a href="#cb146-2" aria-hidden="true" tabindex="-1"></a><span class="co">// already done so.  Also emit the cleanup once.</span></span>
+<span id="cb146-3"><a href="#cb146-3" aria-hidden="true" tabindex="-1"></a><span class="dt">static</span> <span class="dt">void</span> ensure_temp_statement<span class="op">()</span> <span class="op">{</span></span>
+<span id="cb146-4"><a href="#cb146-4" aria-hidden="true" tabindex="-1"></a>  <span class="cf">if</span> <span class="op">(!</span>temp_statement_emitted<span class="op">)</span> <span class="op">{</span></span>
+<span id="cb146-5"><a href="#cb146-5" aria-hidden="true" tabindex="-1"></a>    bprintf<span class="op">(</span>cg_declarations_output<span class="op">,</span> <span class="st">&quot;sqlite3_stmt *_temp_stmt = NULL;</span><span class="sc">\n</span><span class="st">&quot;</span><span class="op">);</span></span>
+<span id="cb146-6"><a href="#cb146-6" aria-hidden="true" tabindex="-1"></a>    bprintf<span class="op">(</span>cg_cleanup_output<span class="op">,</span> <span class="st">&quot;  cql_finalize_stmt(&amp;_temp_stmt);</span><span class="sc">\n</span><span class="st">&quot;</span><span class="op">);</span></span>
+<span id="cb146-7"><a href="#cb146-7" aria-hidden="true" tabindex="-1"></a>    temp_statement_emitted <span class="op">=</span> <span class="dv">1</span><span class="op">;</span></span>
+<span id="cb146-8"><a href="#cb146-8" aria-hidden="true" tabindex="-1"></a>  <span class="op">}</span></span>
+<span id="cb146-9"><a href="#cb146-9" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span></code></pre></div>
+<p>This is a great example of how, no matter where the processing happens to be, the generator can emit things into the various sections. Here it adds a declaration and an cleanup with no concern about what else might be going on.</p>
+<p>So most of the above is just boiler-plate, the tricky part is: * getting the text of the SQL * binding the variables</p>
+<p>All of this is the business of this function:</p>
+<div class="sourceCode" id="cb147"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb147-1"><a href="#cb147-1" aria-hidden="true" tabindex="-1"></a><span class="co">// This is the most important function for sqlite access;  it does the heavy</span></span>
+<span id="cb147-2"><a href="#cb147-2" aria-hidden="true" tabindex="-1"></a><span class="co">// lifting of generating the C code to prepare and bind a SQL statement.</span></span>
+<span id="cb147-3"><a href="#cb147-3" aria-hidden="true" tabindex="-1"></a><span class="co">// If cg_exec is true (CG_EXEC) then the statement is executed immediately</span></span>
+<span id="cb147-4"><a href="#cb147-4" aria-hidden="true" tabindex="-1"></a><span class="co">// and finalized.  No results are expected.  To accomplish this we do the following:</span></span>
+<span id="cb147-5"><a href="#cb147-5" aria-hidden="true" tabindex="-1"></a><span class="co">//   * figure out the name of the statement, either it&#39;s given to us</span></span>
+<span id="cb147-6"><a href="#cb147-6" aria-hidden="true" tabindex="-1"></a><span class="co">//     or we&#39;re using the temp statement</span></span>
+<span id="cb147-7"><a href="#cb147-7" aria-hidden="true" tabindex="-1"></a><span class="co">//   * call get_statement_with_callback to get the text of the SQL from the AST</span></span>
+<span id="cb147-8"><a href="#cb147-8" aria-hidden="true" tabindex="-1"></a><span class="co">//     * the callback will give us all the variables to bind</span></span>
+<span id="cb147-9"><a href="#cb147-9" aria-hidden="true" tabindex="-1"></a><span class="co">//     * count the variables so we know what column numbers to use (the list is backwards!)</span></span>
+<span id="cb147-10"><a href="#cb147-10" aria-hidden="true" tabindex="-1"></a><span class="co">//   * if CG_EXEC and no variables we can use the simpler sqlite3_exec form</span></span>
+<span id="cb147-11"><a href="#cb147-11" aria-hidden="true" tabindex="-1"></a><span class="co">//   * bind any variables</span></span>
+<span id="cb147-12"><a href="#cb147-12" aria-hidden="true" tabindex="-1"></a><span class="co">//   * if there are variables CG_EXEC will step and finalize</span></span>
+<span id="cb147-13"><a href="#cb147-13" aria-hidden="true" tabindex="-1"></a><span class="dt">static</span> <span class="dt">void</span> cg_bound_sql_statement<span class="op">(</span>CSTR stmt_name<span class="op">,</span> ast_node <span class="op">*</span>stmt<span class="op">,</span> <span class="dt">int32_t</span> cg_flags<span class="op">)</span></span>
+<span id="cb147-14"><a href="#cb147-14" aria-hidden="true" tabindex="-1"></a><span class="op">{</span></span>
+<span id="cb147-15"><a href="#cb147-15" aria-hidden="true" tabindex="-1"></a>  <span class="op">...</span></span>
+<span id="cb147-16"><a href="#cb147-16" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span></code></pre></div>
+<p>The core of this function looks like this:</p>
+<div class="sourceCode" id="cb148"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb148-1"><a href="#cb148-1" aria-hidden="true" tabindex="-1"></a>  gen_sql_callbacks callbacks<span class="op">;</span></span>
+<span id="cb148-2"><a href="#cb148-2" aria-hidden="true" tabindex="-1"></a>  init_gen_sql_callbacks<span class="op">(&amp;</span>callbacks<span class="op">);</span></span>
+<span id="cb148-3"><a href="#cb148-3" aria-hidden="true" tabindex="-1"></a>  callbacks<span class="op">.</span>variables_callback <span class="op">=</span> cg_capture_variables<span class="op">;</span></span>
+<span id="cb148-4"><a href="#cb148-4" aria-hidden="true" tabindex="-1"></a>  callbacks<span class="op">.</span>variables_context <span class="op">=</span> <span class="op">&amp;</span>vars<span class="op">;</span></span>
+<span id="cb148-5"><a href="#cb148-5" aria-hidden="true" tabindex="-1"></a>  <span class="co">// ... more flags</span></span>
+<span id="cb148-6"><a href="#cb148-6" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb148-7"><a href="#cb148-7" aria-hidden="true" tabindex="-1"></a>  CHARBUF_OPEN<span class="op">(</span>temp<span class="op">);</span></span>
+<span id="cb148-8"><a href="#cb148-8" aria-hidden="true" tabindex="-1"></a>  gen_set_output_buffer<span class="op">(&amp;</span>temp<span class="op">);</span></span>
+<span id="cb148-9"><a href="#cb148-9" aria-hidden="true" tabindex="-1"></a>  gen_statement_with_callbacks<span class="op">(</span>stmt<span class="op">,</span> <span class="op">&amp;</span>callbacks<span class="op">);</span></span></code></pre></div>
+<p>It’s set up the callbacks for variables and it calls the echoing function on the buffer. We’ve talked about <code>gen_statement_with_callbacks</code> in <a href="https://cgsql.dev/cql-guide/int01">Part 1</a>.</p>
+<p>Let’s take a look at that callback function:</p>
+<pre><code>// This is the callback method handed to the gen_ method that creates SQL for us
+// it will call us every time it finds a variable that needs to be bound.  That
+// variable is replaced by ? in the SQL output.  We end up with a list of variables
+// to bind on a silver platter (but in reverse order).
+static bool_t cg_capture_variables(ast_node *ast, void *context, charbuf *buffer) {
+  list_item **head = (list_item**)context;
+  add_item_to_list(head, ast);
+
+  bprintf(buffer, &quot;?&quot;);
+  return true;
+}</code></pre>
+<p>The <code>context</code> variable was set to be <code>vars</code>, we convert it back to the correct type and add the current ast to that list. <code>add_item_to_list</code> always puts things at the head so the list will be in reverse order.</p>
+<p>With this done, we’re pretty much set. We’ll produce the statement with a sequence like this one (there are a couple of variations, but this is the most general)</p>
+<div class="sourceCode" id="cb150"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb150-1"><a href="#cb150-1" aria-hidden="true" tabindex="-1"></a>  bprintf<span class="op">(</span>cg_main_output<span class="op">,</span> <span class="st">&quot;_rc_ = cql_prepare(_db_, %s%s_stmt,</span><span class="sc">\n</span><span class="st">  &quot;</span><span class="op">,</span> amp<span class="op">,</span> stmt_name<span class="op">);</span></span>
+<span id="cb150-2"><a href="#cb150-2" aria-hidden="true" tabindex="-1"></a>  cg_pretty_quote_plaintext<span class="op">(</span>temp<span class="op">.</span>ptr<span class="op">,</span> cg_main_output<span class="op">,</span> PRETTY_QUOTE_C <span class="op">|</span> PRETTY_QUOTE_MULTI_LINE<span class="op">);</span></span>
+<span id="cb150-3"><a href="#cb150-3" aria-hidden="true" tabindex="-1"></a>  bprintf<span class="op">(</span>cg_main_output<span class="op">,</span> <span class="st">&quot;);</span><span class="sc">\n</span><span class="st">&quot;</span><span class="op">);</span></span></code></pre></div>
+<p><code>cg_pretty_quote_plaintext</code> is one of the C string encoding formats, it could have been just the regular C string encoding but that would have been a bit wasteful and it wouldn’t have looked as nice. This function does a little transform.</p>
+<p>The normal echo of the update statement in question looks like this:</p>
+<pre><code>  UPDATE foo
+  SET t = ?
+    WHERE id = ?;</code></pre>
+<p>Note that it has indenting and newlines embedded in it. The standard encoding of that would look like this:</p>
+<div class="sourceCode" id="cb152"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb152-1"><a href="#cb152-1" aria-hidden="true" tabindex="-1"></a><span class="st">&quot;  UPDATE foo</span><span class="sc">\n</span><span class="st">  SET t = ?</span><span class="sc">\n</span><span class="st">    WHERE id = ?;&quot;</span></span></code></pre></div>
+<p>That surely works, but it’s wasteful and ugly. The pretty format instead produces:</p>
+<div class="sourceCode" id="cb153"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb153-1"><a href="#cb153-1" aria-hidden="true" tabindex="-1"></a>    <span class="st">&quot;UPDATE foo &quot;</span></span>
+<span id="cb153-2"><a href="#cb153-2" aria-hidden="true" tabindex="-1"></a>    <span class="st">&quot;SET t = ? &quot;</span></span>
+<span id="cb153-3"><a href="#cb153-3" aria-hidden="true" tabindex="-1"></a>      <span class="st">&quot;WHERE id = ?&quot;</span></span></code></pre></div>
+<p>So, the newlines are gone from the string (they aren’t needed), instead the string literal was broken into lines for readability. The indenting is gone from the string, instead the string fragments are indented. So what you get is a string literal that reads nicely but doesn’t have unnecessary whitespace for SQLite. Obviously you can’t use pretty-quoted literals in all cases, it’s exclusively for SQLite formatting.</p>
+<p>All that’s left to do is bind the arguments. Remember that arg list is in reverse order:</p>
+<div class="sourceCode" id="cb154"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb154-1"><a href="#cb154-1" aria-hidden="true" tabindex="-1"></a>  <span class="dt">uint32_t</span> count <span class="op">=</span> <span class="dv">0</span><span class="op">;</span></span>
+<span id="cb154-2"><a href="#cb154-2" aria-hidden="true" tabindex="-1"></a>  <span class="cf">for</span> <span class="op">(</span>list_item <span class="op">*</span>item <span class="op">=</span> vars<span class="op">;</span> item<span class="op">;</span> item <span class="op">=</span> item<span class="op">-&gt;</span>next<span class="op">,</span> count<span class="op">++)</span> <span class="op">;</span></span>
+<span id="cb154-3"><a href="#cb154-3" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb154-4"><a href="#cb154-4" aria-hidden="true" tabindex="-1"></a>  <span class="co">// ...</span></span>
+<span id="cb154-5"><a href="#cb154-5" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb154-6"><a href="#cb154-6" aria-hidden="true" tabindex="-1"></a>  reverse_list<span class="op">(&amp;</span>vars<span class="op">);</span></span>
+<span id="cb154-7"><a href="#cb154-7" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb154-8"><a href="#cb154-8" aria-hidden="true" tabindex="-1"></a>  <span class="cf">if</span> <span class="op">(</span>count<span class="op">)</span> <span class="op">{</span></span>
+<span id="cb154-9"><a href="#cb154-9" aria-hidden="true" tabindex="-1"></a>    bprintf<span class="op">(</span>cg_main_output<span class="op">,</span> <span class="st">&quot;cql_multibind(&amp;_rc_, _db_, %s%s_stmt, %d&quot;</span><span class="op">,</span> amp<span class="op">,</span> stmt_name<span class="op">,</span> count<span class="op">);</span></span>
+<span id="cb154-10"><a href="#cb154-10" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb154-11"><a href="#cb154-11" aria-hidden="true" tabindex="-1"></a>    <span class="co">// Now emit the binding args for each variable</span></span>
+<span id="cb154-12"><a href="#cb154-12" aria-hidden="true" tabindex="-1"></a>    <span class="cf">for</span> <span class="op">(</span>list_item <span class="op">*</span>item <span class="op">=</span> vars<span class="op">;</span> item<span class="op">;</span> item <span class="op">=</span> item<span class="op">-&gt;</span>next<span class="op">)</span>  <span class="op">{</span></span>
+<span id="cb154-13"><a href="#cb154-13" aria-hidden="true" tabindex="-1"></a>      Contract<span class="op">(</span>item<span class="op">-&gt;</span>ast<span class="op">-&gt;</span>sem<span class="op">-&gt;</span>name<span class="op">);</span></span>
+<span id="cb154-14"><a href="#cb154-14" aria-hidden="true" tabindex="-1"></a>      bprintf<span class="op">(</span>cg_main_output<span class="op">,</span> <span class="st">&quot;,</span><span class="sc">\n</span><span class="st">              &quot;</span><span class="op">);</span></span>
+<span id="cb154-15"><a href="#cb154-15" aria-hidden="true" tabindex="-1"></a>      cg_bind_column<span class="op">(</span>item<span class="op">-&gt;</span>ast<span class="op">-&gt;</span>sem<span class="op">-&gt;</span>sem_type<span class="op">,</span> item<span class="op">-&gt;</span>ast<span class="op">-&gt;</span>sem<span class="op">-&gt;</span>name<span class="op">);</span></span>
+<span id="cb154-16"><a href="#cb154-16" aria-hidden="true" tabindex="-1"></a>    <span class="op">}</span></span>
+<span id="cb154-17"><a href="#cb154-17" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb154-18"><a href="#cb154-18" aria-hidden="true" tabindex="-1"></a>    bprintf<span class="op">(</span>cg_main_output<span class="op">,</span> <span class="st">&quot;);</span><span class="sc">\n</span><span class="st">&quot;</span><span class="op">);</span></span>
+<span id="cb154-19"><a href="#cb154-19" aria-hidden="true" tabindex="-1"></a>  <span class="op">}</span></span></code></pre></div>
+<ul>
+<li>first compute the count, we don’t need to bind if there are no variables</li>
+<li><code>reverse_list</code> does exactly what is sounds like (finally a real-world use-case for reverse-list-in-place)</li>
+<li><code>cg_bind_column</code> creates one line of the var-args output: column type and variable name
+<ul>
+<li>the type and name information is right there on the <code>AST</code> in the <code>sem_node</code></li>
+</ul></li>
+</ul>
+<p>And that’s it. With those few helpers we can bind any SQLite statement the same way. All of the <code>DDL_STMT_INIT</code> and <code>DML_STMT_INIT</code> statements are completely implemented by this path.</p>
+<h3 id="reading-single-values">Reading Single Values</h3>
+<p>In many cases you need just one value</p>
+<div class="sourceCode" id="cb155"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb155-1"><a href="#cb155-1" aria-hidden="true" tabindex="-1"></a><span class="kw">CREATE</span> PROC p (id_ <span class="dt">INTEGER</span> <span class="kw">NOT</span> <span class="kw">NULL</span>, <span class="kw">OUT</span> t_ TEXT)</span>
+<span id="cb155-2"><a href="#cb155-2" aria-hidden="true" tabindex="-1"></a><span class="cf">BEGIN</span></span>
+<span id="cb155-3"><a href="#cb155-3" aria-hidden="true" tabindex="-1"></a>  <span class="kw">SET</span> t_ <span class="op">:=</span> ( <span class="kw">SELECT</span> t</span>
+<span id="cb155-4"><a href="#cb155-4" aria-hidden="true" tabindex="-1"></a>    <span class="kw">FROM</span> foo</span>
+<span id="cb155-5"><a href="#cb155-5" aria-hidden="true" tabindex="-1"></a>    <span class="kw">WHERE</span> <span class="kw">id</span> <span class="op">=</span> id_ );</span>
+<span id="cb155-6"><a href="#cb155-6" aria-hidden="true" tabindex="-1"></a><span class="cf">END</span>;</span></code></pre></div>
+<p>This is going to be very similar to the examples we’ve seen so far:</p>
+<div class="sourceCode" id="cb156"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb156-1"><a href="#cb156-1" aria-hidden="true" tabindex="-1"></a>CQL_WARN_UNUSED cql_code p<span class="op">(</span>sqlite3 <span class="op">*</span>_Nonnull _db_<span class="op">,</span> cql_int32 id_<span class="op">,</span> cql_string_ref _Nullable <span class="op">*</span>_Nonnull t_<span class="op">)</span> <span class="op">{</span></span>
+<span id="cb156-2"><a href="#cb156-2" aria-hidden="true" tabindex="-1"></a>  cql_contract_argument_notnull<span class="op">((</span><span class="dt">void</span> <span class="op">*)</span>t_<span class="op">,</span> <span class="dv">2</span><span class="op">);</span></span>
+<span id="cb156-3"><a href="#cb156-3" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb156-4"><a href="#cb156-4" aria-hidden="true" tabindex="-1"></a>  cql_code _rc_ <span class="op">=</span> SQLITE_OK<span class="op">;</span></span>
+<span id="cb156-5"><a href="#cb156-5" aria-hidden="true" tabindex="-1"></a>  cql_string_ref _tmp_text_0 <span class="op">=</span> NULL<span class="op">;</span></span>
+<span id="cb156-6"><a href="#cb156-6" aria-hidden="true" tabindex="-1"></a>  sqlite3_stmt <span class="op">*</span>_temp_stmt <span class="op">=</span> NULL<span class="op">;</span></span>
+<span id="cb156-7"><a href="#cb156-7" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb156-8"><a href="#cb156-8" aria-hidden="true" tabindex="-1"></a>  <span class="op">*(</span><span class="dt">void</span> <span class="op">**)</span>t_ <span class="op">=</span> NULL<span class="op">;</span> <span class="co">// set out arg to non-garbage</span></span>
+<span id="cb156-9"><a href="#cb156-9" aria-hidden="true" tabindex="-1"></a>  _rc_ <span class="op">=</span> cql_prepare<span class="op">(</span>_db_<span class="op">,</span> <span class="op">&amp;</span>_temp_stmt<span class="op">,</span></span>
+<span id="cb156-10"><a href="#cb156-10" aria-hidden="true" tabindex="-1"></a>    <span class="st">&quot;SELECT t &quot;</span></span>
+<span id="cb156-11"><a href="#cb156-11" aria-hidden="true" tabindex="-1"></a>      <span class="st">&quot;FROM foo &quot;</span></span>
+<span id="cb156-12"><a href="#cb156-12" aria-hidden="true" tabindex="-1"></a>      <span class="st">&quot;WHERE id = ?&quot;</span><span class="op">);</span></span>
+<span id="cb156-13"><a href="#cb156-13" aria-hidden="true" tabindex="-1"></a>  cql_multibind<span class="op">(&amp;</span>_rc_<span class="op">,</span> _db_<span class="op">,</span> <span class="op">&amp;</span>_temp_stmt<span class="op">,</span> <span class="dv">1</span><span class="op">,</span></span>
+<span id="cb156-14"><a href="#cb156-14" aria-hidden="true" tabindex="-1"></a>                CQL_DATA_TYPE_NOT_NULL <span class="op">|</span> CQL_DATA_TYPE_INT32<span class="op">,</span> id_<span class="op">);</span></span>
+<span id="cb156-15"><a href="#cb156-15" aria-hidden="true" tabindex="-1"></a>  <span class="cf">if</span> <span class="op">(</span>_rc_ <span class="op">!=</span> SQLITE_OK<span class="op">)</span> <span class="op">{</span> cql_error_trace<span class="op">();</span> <span class="cf">goto</span> cql_cleanup<span class="op">;</span> <span class="op">}</span></span>
+<span id="cb156-16"><a href="#cb156-16" aria-hidden="true" tabindex="-1"></a>  _rc_ <span class="op">=</span> sqlite3_step<span class="op">(</span>_temp_stmt<span class="op">);</span></span>
+<span id="cb156-17"><a href="#cb156-17" aria-hidden="true" tabindex="-1"></a>  <span class="cf">if</span> <span class="op">(</span>_rc_ <span class="op">!=</span> SQLITE_ROW<span class="op">)</span> <span class="op">{</span> cql_error_trace<span class="op">();</span> <span class="cf">goto</span> cql_cleanup<span class="op">;</span> <span class="op">}</span></span>
+<span id="cb156-18"><a href="#cb156-18" aria-hidden="true" tabindex="-1"></a>    cql_column_string_ref<span class="op">(</span>_temp_stmt<span class="op">,</span> <span class="dv">0</span><span class="op">,</span> <span class="op">&amp;</span>_tmp_text_0<span class="op">);</span></span>
+<span id="cb156-19"><a href="#cb156-19" aria-hidden="true" tabindex="-1"></a>  cql_finalize_stmt<span class="op">(&amp;</span>_temp_stmt<span class="op">);</span></span>
+<span id="cb156-20"><a href="#cb156-20" aria-hidden="true" tabindex="-1"></a>  cql_set_string_ref<span class="op">(&amp;*</span>t_<span class="op">,</span> _tmp_text_0<span class="op">);</span></span>
+<span id="cb156-21"><a href="#cb156-21" aria-hidden="true" tabindex="-1"></a>  _rc_ <span class="op">=</span> SQLITE_OK<span class="op">;</span></span>
+<span id="cb156-22"><a href="#cb156-22" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb156-23"><a href="#cb156-23" aria-hidden="true" tabindex="-1"></a>cql_cleanup<span class="op">:</span></span>
+<span id="cb156-24"><a href="#cb156-24" aria-hidden="true" tabindex="-1"></a>  cql_string_release<span class="op">(</span>_tmp_text_0<span class="op">);</span></span>
+<span id="cb156-25"><a href="#cb156-25" aria-hidden="true" tabindex="-1"></a>  cql_finalize_stmt<span class="op">(&amp;</span>_temp_stmt<span class="op">);</span></span>
+<span id="cb156-26"><a href="#cb156-26" aria-hidden="true" tabindex="-1"></a>  <span class="cf">return</span> _rc_<span class="op">;</span></span>
+<span id="cb156-27"><a href="#cb156-27" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span></code></pre></div>
+<ul>
+<li><code>_db_</code> : incoming arg for a procedure that uses the database same as always, check</li>
+<li><code>*(void **)t_ = NULL;</code> : out args are always set to NULL on entry, note, there is no <code>release</code> here
+<ul>
+<li>argument is assumed to be garbage, that’s the ABI</li>
+<li>if argument is non-garbage caller must release it first, that’s the ABI</li>
+</ul></li>
+<li><code>_rc_</code> : same as always, check</li>
+<li><code>_tmp_text_0</code> : new temporary text, including cleanup (this could have been avoided)</li>
+<li><code>_temp_stmt</code> : as before, including cleanup</li>
+<li><code>cql_prepare</code> : same as always, check</li>
+<li><code>cql_multibind</code> : just one integer bound this time</li>
+<li><code>sqlite3_step</code> : as before, we’re stepping once, this time we want the data</li>
+<li><code>if (_rc_ != SQLITE_ROW)</code> new error check and goto cleanup if no row
+<ul>
+<li>this is the same as the <code>IF NOTHING THROW</code> variant of construct, that’s the default</li>
+</ul></li>
+<li><code>cql_column_string_ref</code> : reads one string from <code>_temp_stmt</code></li>
+<li><code>cql_finalize_stmt</code> : as before</li>
+<li><code>cql_set_string_ref(&amp;*t_, _tmp_text_0)</code> : copy the temporary string to the out arg
+<ul>
+<li>includes retain, out arg is NULL so <code>cql_set_string_ref</code> will do no release</li>
+<li>if this were (e.g.) running in a loop, the out arg would not be null and there would be a release, as expected</li>
+<li>if something else had previously set the out arg, again, there would be a release as expected</li>
+</ul></li>
+</ul>
+<p>There are variations of this form such as:</p>
+<div class="sourceCode" id="cb157"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb157-1"><a href="#cb157-1" aria-hidden="true" tabindex="-1"></a><span class="kw">CREATE</span> PROC p (id_ <span class="dt">INTEGER</span> <span class="kw">NOT</span> <span class="kw">NULL</span>, <span class="kw">OUT</span> t_ TEXT)</span>
+<span id="cb157-2"><a href="#cb157-2" aria-hidden="true" tabindex="-1"></a><span class="cf">BEGIN</span></span>
+<span id="cb157-3"><a href="#cb157-3" aria-hidden="true" tabindex="-1"></a>  <span class="kw">SET</span> t_ <span class="op">:=</span> ( <span class="kw">SELECT</span> t</span>
+<span id="cb157-4"><a href="#cb157-4" aria-hidden="true" tabindex="-1"></a>    <span class="kw">FROM</span> foo</span>
+<span id="cb157-5"><a href="#cb157-5" aria-hidden="true" tabindex="-1"></a>    <span class="kw">WHERE</span> <span class="kw">id</span> <span class="op">=</span> id_</span>
+<span id="cb157-6"><a href="#cb157-6" aria-hidden="true" tabindex="-1"></a>    <span class="cf">IF</span> <span class="kw">NOTHING</span> <span class="st">&#39;&#39;</span>);</span>
+<span id="cb157-7"><a href="#cb157-7" aria-hidden="true" tabindex="-1"></a><span class="cf">END</span>;</span></code></pre></div>
+<p>This simply changes the handling of the case where there is no row. The that part of the code ends up looking like this:</p>
+<div class="sourceCode" id="cb158"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb158-1"><a href="#cb158-1" aria-hidden="true" tabindex="-1"></a>  <span class="cf">if</span> <span class="op">(</span>_rc_ <span class="op">!=</span> SQLITE_ROW <span class="op">&amp;&amp;</span> _rc_ <span class="op">!=</span> SQLITE_DONE<span class="op">)</span> <span class="op">{</span> cql_error_trace<span class="op">();</span> <span class="cf">goto</span> cql_cleanup<span class="op">;</span> <span class="op">}</span></span>
+<span id="cb158-2"><a href="#cb158-2" aria-hidden="true" tabindex="-1"></a>  <span class="cf">if</span> <span class="op">(</span>_rc_ <span class="op">==</span> SQLITE_ROW<span class="op">)</span> <span class="op">{</span></span>
+<span id="cb158-3"><a href="#cb158-3" aria-hidden="true" tabindex="-1"></a>    cql_column_string_ref<span class="op">(</span>_temp_stmt<span class="op">,</span> <span class="dv">0</span><span class="op">,</span> <span class="op">&amp;</span>_tmp_text_1<span class="op">);</span></span>
+<span id="cb158-4"><a href="#cb158-4" aria-hidden="true" tabindex="-1"></a>    cql_set_string_ref<span class="op">(&amp;</span>_tmp_text_0<span class="op">,</span> _tmp_text_1<span class="op">);</span></span>
+<span id="cb158-5"><a href="#cb158-5" aria-hidden="true" tabindex="-1"></a>  <span class="op">}</span></span>
+<span id="cb158-6"><a href="#cb158-6" aria-hidden="true" tabindex="-1"></a>  <span class="cf">else</span> <span class="op">{</span></span>
+<span id="cb158-7"><a href="#cb158-7" aria-hidden="true" tabindex="-1"></a>    cql_set_string_ref<span class="op">(&amp;</span>_tmp_text_0<span class="op">,</span> _literal_1_p<span class="op">);</span></span>
+<span id="cb158-8"><a href="#cb158-8" aria-hidden="true" tabindex="-1"></a>  <span class="op">}</span></span></code></pre></div>
+<ul>
+<li>any error code leads to cleanup</li>
+<li><code>SQLITE_ROW</code> : leads to the same fetch as before</li>
+<li><code>SQLITE_DONE</code> : leads to the no row case which sets <code>_tmp_text_0</code> to the empty string
+<ul>
+<li><code>cql_string_literal(_literal_1_p, "");</code> is included as a data declaration</li>
+</ul></li>
+</ul>
+<p>There is also the <code>IF NOTHING OR NULL</code> variant which is left as an exercise to the reader. You can find all the flavors in <code>cg_c.c</code> in the this function:</p>
+<div class="sourceCode" id="cb159"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb159-1"><a href="#cb159-1" aria-hidden="true" tabindex="-1"></a><span class="co">// This is a nested select expression.  To evaluate we will</span></span>
+<span id="cb159-2"><a href="#cb159-2" aria-hidden="true" tabindex="-1"></a><span class="co">//  * prepare a temporary to hold the result</span></span>
+<span id="cb159-3"><a href="#cb159-3" aria-hidden="true" tabindex="-1"></a><span class="co">//  * generate the bound SQL statement</span></span>
+<span id="cb159-4"><a href="#cb159-4" aria-hidden="true" tabindex="-1"></a><span class="co">//  * extract the exactly one argument into the result variable</span></span>
+<span id="cb159-5"><a href="#cb159-5" aria-hidden="true" tabindex="-1"></a><span class="co">//    which is of exactly the right type</span></span>
+<span id="cb159-6"><a href="#cb159-6" aria-hidden="true" tabindex="-1"></a><span class="co">//  * use that variable as the result.</span></span>
+<span id="cb159-7"><a href="#cb159-7" aria-hidden="true" tabindex="-1"></a><span class="co">// The helper methods take care of sqlite error management.</span></span>
+<span id="cb159-8"><a href="#cb159-8" aria-hidden="true" tabindex="-1"></a><span class="dt">static</span> <span class="dt">void</span> cg_expr_select<span class="op">(...</span></span></code></pre></div>
+<p>This handles all of the <code>(select ...)</code> expressions and it has the usual expression handler syntax. Another great example of a CQL expressions that might require many C statements to implement.</p>
+<h3 id="reading-rows-with-cursors">Reading Rows With Cursors</h3>
+<p>This section is about the cases where we are expecting results back from SQLite. By results here I mean the results of some kind of query, not like a return code. SQLite does this by giving you a <code>sqlite3_stmt *</code> which you can then use like a cursor to read out a bunch of rows. So it should be no surprise that CQL cursors map directly to SQLite statements.</p>
+<p>Most of the code to get a statement we’ve already seen before, we only saw the <code>_temp_stmt</code> case and we did very little with it. Let’s look at the code for something a little bit more general and we’ll see how little it takes to generalize.</p>
+<p>First, let’s look at how a CQL cursor is initialized:</p>
+<div class="sourceCode" id="cb160"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb160-1"><a href="#cb160-1" aria-hidden="true" tabindex="-1"></a><span class="kw">CREATE</span> PROC p ()</span>
+<span id="cb160-2"><a href="#cb160-2" aria-hidden="true" tabindex="-1"></a><span class="cf">BEGIN</span></span>
+<span id="cb160-3"><a href="#cb160-3" aria-hidden="true" tabindex="-1"></a>  <span class="kw">DECLARE</span> C <span class="kw">CURSOR</span> <span class="cf">FOR</span> <span class="kw">SELECT</span> <span class="dv">1</span> <span class="kw">AS</span> x, <span class="dv">2</span> <span class="kw">AS</span> y;</span>
+<span id="cb160-4"><a href="#cb160-4" aria-hidden="true" tabindex="-1"></a><span class="cf">END</span>;</span></code></pre></div>
+<p>Now in this case there can only be one row in the result, but it would be no different if there were more.</p>
+<p>Here’s the C code:</p>
+<div class="sourceCode" id="cb161"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb161-1"><a href="#cb161-1" aria-hidden="true" tabindex="-1"></a>CQL_WARN_UNUSED cql_code p<span class="op">(</span>sqlite3 <span class="op">*</span>_Nonnull _db_<span class="op">)</span> <span class="op">{</span></span>
+<span id="cb161-2"><a href="#cb161-2" aria-hidden="true" tabindex="-1"></a>  cql_code _rc_ <span class="op">=</span> SQLITE_OK<span class="op">;</span></span>
+<span id="cb161-3"><a href="#cb161-3" aria-hidden="true" tabindex="-1"></a>  sqlite3_stmt <span class="op">*</span>C_stmt <span class="op">=</span> NULL<span class="op">;</span></span>
+<span id="cb161-4"><a href="#cb161-4" aria-hidden="true" tabindex="-1"></a>  cql_bool _C_has_row_ <span class="op">=</span> <span class="dv">0</span><span class="op">;</span></span>
+<span id="cb161-5"><a href="#cb161-5" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb161-6"><a href="#cb161-6" aria-hidden="true" tabindex="-1"></a>  _rc_ <span class="op">=</span> cql_prepare<span class="op">(</span>_db_<span class="op">,</span> <span class="op">&amp;</span>C_stmt<span class="op">,</span></span>
+<span id="cb161-7"><a href="#cb161-7" aria-hidden="true" tabindex="-1"></a>    <span class="st">&quot;SELECT 1, 2&quot;</span><span class="op">);</span></span>
+<span id="cb161-8"><a href="#cb161-8" aria-hidden="true" tabindex="-1"></a>  <span class="cf">if</span> <span class="op">(</span>_rc_ <span class="op">!=</span> SQLITE_OK<span class="op">)</span> <span class="op">{</span> cql_error_trace<span class="op">();</span> <span class="cf">goto</span> cql_cleanup<span class="op">;</span> <span class="op">}</span></span>
+<span id="cb161-9"><a href="#cb161-9" aria-hidden="true" tabindex="-1"></a>  _rc_ <span class="op">=</span> SQLITE_OK<span class="op">;</span></span>
+<span id="cb161-10"><a href="#cb161-10" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb161-11"><a href="#cb161-11" aria-hidden="true" tabindex="-1"></a>cql_cleanup<span class="op">:</span></span>
+<span id="cb161-12"><a href="#cb161-12" aria-hidden="true" tabindex="-1"></a>  cql_finalize_stmt<span class="op">(&amp;</span>C_stmt<span class="op">);</span></span>
+<span id="cb161-13"><a href="#cb161-13" aria-hidden="true" tabindex="-1"></a>  <span class="cf">return</span> _rc_<span class="op">;</span></span>
+<span id="cb161-14"><a href="#cb161-14" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span></code></pre></div>
+<p>Let’s look over that code very carefully and see what is necessary to make it happen.</p>
+<ul>
+<li><code>_db_</code> : incoming arg for a procedure that uses the database same as always, check</li>
+<li><code>_rc_</code> : same as always, check</li>
+<li><code>C_stmt</code> : we need to generate this instead of using <code>_temp_stmt</code>
+<ul>
+<li><code>cql_finalize_stmt(&amp;C_stmt)</code> in cleanup, just like <code>_temp_stmt</code></li>
+</ul></li>
+<li><code>cql_prepare</code> : same as always, check</li>
+<li><code>cql_multibind</code> : could have been binding, not none needed here, but same as always anyway, check</li>
+<li>no step, no finalize (until cleanup) : that boiler-plate is removed</li>
+</ul>
+<p>And that’s it, we now have a statement in <code>C_stmt</code> ready to go. We’ll see later that <code>_C_has_row_</code> will track whether or not the cursor has any data in it.</p>
+<p>How do we make this happen? Well you could look at <code>cg_declare_cursor</code> and your eye might hurt at first. The truth is there are many kinds of cursors in CQL and this method handles all of them. We’re going to go over the various flavors but for now we’re only discussing the so-called “statement cursor”, so named because it simply holds a SQLite statement. This was the first, and for a while only, type of cursor added to the CQL language.</p>
+<p>OK so how do we make a statement cursor. It’s once again <code>cg_bound_sql_statement</code> just like so:</p>
+<div class="sourceCode" id="cb162"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb162-1"><a href="#cb162-1" aria-hidden="true" tabindex="-1"></a>cg_bound_sql_statement<span class="op">(</span>cursor_name<span class="op">,</span> select_stmt<span class="op">,</span> CG_PREPARE<span class="op">|</span>CG_MINIFY_ALIASES<span class="op">);</span></span></code></pre></div>
+<p>The entire difference is that the first argument is the cursor name rather than NULL. If you pass NULL it means use the temporary statement.</p>
+<p>And you’ll notice that even in this simple example the SQLite text was altered a bit: the text that went to SQLite was <code>"SELECT 1, 2"</code> – that’s CG_MINIFY_ALIASES at work. SQLite didn’t need to see those column aliases, it makes no difference in the result. Column aliases are often long and numerous. Even in this simple example we saved 4 bytes. But the entire query was only 12 bytes long (including trailing null) so that’s 25%. It’s not a huge savings in general but it’s something.</p>
+<p>The other flag <code>CG_PREPARE</code> tells the binder that it should not step or finalize the query. The alternative is <code>CG_EXEC</code> (which was used in the previous section for the <code>UPDATE</code> example).</p>
+<h3 id="fetching-data-from-cursors">Fetching Data From Cursors</h3>
+<p>The first cursor reading primitive that was implemented as <code>FETCH [cursor] INTO [variables]</code> and it’s the simplest to understand so let’s start there.</p>
+<p>We change the example just a bit:</p>
+<div class="sourceCode" id="cb163"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb163-1"><a href="#cb163-1" aria-hidden="true" tabindex="-1"></a><span class="kw">CREATE</span> PROC p ()</span>
+<span id="cb163-2"><a href="#cb163-2" aria-hidden="true" tabindex="-1"></a><span class="cf">BEGIN</span></span>
+<span id="cb163-3"><a href="#cb163-3" aria-hidden="true" tabindex="-1"></a>  <span class="kw">DECLARE</span> x <span class="dt">INTEGER</span> <span class="kw">NOT</span> <span class="kw">NULL</span>;</span>
+<span id="cb163-4"><a href="#cb163-4" aria-hidden="true" tabindex="-1"></a>  <span class="kw">DECLARE</span> y <span class="dt">INTEGER</span> <span class="kw">NOT</span> <span class="kw">NULL</span>;</span>
+<span id="cb163-5"><a href="#cb163-5" aria-hidden="true" tabindex="-1"></a>  <span class="kw">DECLARE</span> C <span class="kw">CURSOR</span> <span class="cf">FOR</span> <span class="kw">SELECT</span> <span class="dv">1</span> <span class="kw">AS</span> x, <span class="dv">2</span> <span class="kw">AS</span> y;</span>
+<span id="cb163-6"><a href="#cb163-6" aria-hidden="true" tabindex="-1"></a>  FETCH C <span class="kw">INTO</span> x, y;</span>
+<span id="cb163-7"><a href="#cb163-7" aria-hidden="true" tabindex="-1"></a><span class="cf">END</span>;</span></code></pre></div>
+<p>For simplicity I will only include the code that is added. The rest is the same.</p>
+<div class="sourceCode" id="cb164"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb164-1"><a href="#cb164-1" aria-hidden="true" tabindex="-1"></a>  cql_int32 x <span class="op">=</span> <span class="dv">0</span><span class="op">;</span></span>
+<span id="cb164-2"><a href="#cb164-2" aria-hidden="true" tabindex="-1"></a>  cql_int32 y <span class="op">=</span> <span class="dv">0</span><span class="op">;</span></span>
+<span id="cb164-3"><a href="#cb164-3" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb164-4"><a href="#cb164-4" aria-hidden="true" tabindex="-1"></a>  <span class="co">// same as before</span></span>
+<span id="cb164-5"><a href="#cb164-5" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb164-6"><a href="#cb164-6" aria-hidden="true" tabindex="-1"></a>  _rc_ <span class="op">=</span> sqlite3_step<span class="op">(</span>C_stmt<span class="op">);</span></span>
+<span id="cb164-7"><a href="#cb164-7" aria-hidden="true" tabindex="-1"></a>  _C_has_row_ <span class="op">=</span> _rc_ <span class="op">==</span> SQLITE_ROW<span class="op">;</span></span>
+<span id="cb164-8"><a href="#cb164-8" aria-hidden="true" tabindex="-1"></a>  cql_multifetch<span class="op">(</span>_rc_<span class="op">,</span> C_stmt<span class="op">,</span> <span class="dv">2</span><span class="op">,</span></span>
+<span id="cb164-9"><a href="#cb164-9" aria-hidden="true" tabindex="-1"></a>                 CQL_DATA_TYPE_NOT_NULL <span class="op">|</span> CQL_DATA_TYPE_INT32<span class="op">,</span> <span class="op">&amp;</span>x<span class="op">,</span></span>
+<span id="cb164-10"><a href="#cb164-10" aria-hidden="true" tabindex="-1"></a>                 CQL_DATA_TYPE_NOT_NULL <span class="op">|</span> CQL_DATA_TYPE_INT32<span class="op">,</span> <span class="op">&amp;</span>y<span class="op">);</span></span>
+<span id="cb164-11"><a href="#cb164-11" aria-hidden="true" tabindex="-1"></a>  <span class="cf">if</span> <span class="op">(</span>_rc_ <span class="op">!=</span> SQLITE_ROW <span class="op">&amp;&amp;</span> _rc_ <span class="op">!=</span> SQLITE_DONE<span class="op">)</span> <span class="op">{</span> cql_error_trace<span class="op">();</span> <span class="cf">goto</span> cql_cleanup<span class="op">;</span> <span class="op">}</span></span></code></pre></div>
+<p>Do to the <code>FETCH</code> we do the following:</p>
+<ul>
+<li>step the cursor</li>
+<li>set the <code>_C_has_row_</code> variable so to indicate if we got a row or not</li>
+<li>use the varargs <code>cql_multifetch</code> to read 2 columns from the cursor
+<ul>
+<li>this helper simply uses the usual <code>sqlite3_*_column</code> functions to read the data out</li>
+<li>again, we do it this way so that there is less error checking needed in the generated code</li>
+<li>also, there are fewer function calls so the code is overall smaller</li>
+<li>trivia: <code>multibind</code> and <code>multifetch</code> are totally references to <em>The Fifth Element</em>
+<ul>
+<li>hence, they should be pronouced like Leeloo saying “multipass”</li>
+</ul></li>
+</ul></li>
+<li><code>multifetch</code> uses the varargs to clobber the contents of the target variables if there is no row according to <code>_rc_</code></li>
+<li><code>multifetch</code> uses the <code>CQL_DATA_TYPE_NOT_NULL</code> to decide if it should ask SQLite first if the column is null</li>
+</ul>
+<p>So now this begs the question, in the CQL, how do you know if a row was fetched or not?</p>
+<p>The answer is, you can use the cursor name like a boolean. Let’s complicate this up a little more.</p>
+<div class="sourceCode" id="cb165"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb165-1"><a href="#cb165-1" aria-hidden="true" tabindex="-1"></a><span class="kw">DECLARE</span> <span class="kw">PROCEDURE</span> printf <span class="kw">NO</span> <span class="kw">CHECK</span>;</span>
+<span id="cb165-2"><a href="#cb165-2" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb165-3"><a href="#cb165-3" aria-hidden="true" tabindex="-1"></a><span class="kw">CREATE</span> PROC p ()</span>
+<span id="cb165-4"><a href="#cb165-4" aria-hidden="true" tabindex="-1"></a><span class="cf">BEGIN</span></span>
+<span id="cb165-5"><a href="#cb165-5" aria-hidden="true" tabindex="-1"></a>  <span class="kw">DECLARE</span> x <span class="dt">INTEGER</span> <span class="kw">NOT</span> <span class="kw">NULL</span>;</span>
+<span id="cb165-6"><a href="#cb165-6" aria-hidden="true" tabindex="-1"></a>  <span class="kw">DECLARE</span> y <span class="dt">INTEGER</span> <span class="kw">NOT</span> <span class="kw">NULL</span>;</span>
+<span id="cb165-7"><a href="#cb165-7" aria-hidden="true" tabindex="-1"></a>  <span class="kw">DECLARE</span> C <span class="kw">CURSOR</span> <span class="cf">FOR</span> <span class="kw">SELECT</span> <span class="dv">1</span> <span class="kw">AS</span> x, <span class="dv">2</span> <span class="kw">AS</span> y;</span>
+<span id="cb165-8"><a href="#cb165-8" aria-hidden="true" tabindex="-1"></a>  FETCH C <span class="kw">INTO</span> x, y;</span>
+<span id="cb165-9"><a href="#cb165-9" aria-hidden="true" tabindex="-1"></a>  <span class="cf">WHILE</span> C</span>
+<span id="cb165-10"><a href="#cb165-10" aria-hidden="true" tabindex="-1"></a>  <span class="cf">BEGIN</span></span>
+<span id="cb165-11"><a href="#cb165-11" aria-hidden="true" tabindex="-1"></a>    <span class="kw">CALL</span> printf(<span class="ot">&quot;%d, %d\n&quot;</span>, x, y);</span>
+<span id="cb165-12"><a href="#cb165-12" aria-hidden="true" tabindex="-1"></a>    FETCH C <span class="kw">INTO</span> x, y;</span>
+<span id="cb165-13"><a href="#cb165-13" aria-hidden="true" tabindex="-1"></a>  <span class="cf">END</span>;</span>
+<span id="cb165-14"><a href="#cb165-14" aria-hidden="true" tabindex="-1"></a><span class="cf">END</span>;</span></code></pre></div>
+<p>Again here is what is now added, we’ve seen the <code>WHILE</code> pattern before:</p>
+<div class="sourceCode" id="cb166"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb166-1"><a href="#cb166-1" aria-hidden="true" tabindex="-1"></a>  <span class="cf">for</span> <span class="op">(;;)</span> <span class="op">{</span></span>
+<span id="cb166-2"><a href="#cb166-2" aria-hidden="true" tabindex="-1"></a>  <span class="cf">if</span> <span class="op">(!(</span>_C_has_row_<span class="op">))</span> <span class="cf">break</span><span class="op">;</span></span>
+<span id="cb166-3"><a href="#cb166-3" aria-hidden="true" tabindex="-1"></a>    printf<span class="op">(</span><span class="st">&quot;%d, %d</span><span class="sc">\n</span><span class="st">&quot;</span><span class="op">,</span> x<span class="op">,</span> y<span class="op">);</span></span>
+<span id="cb166-4"><a href="#cb166-4" aria-hidden="true" tabindex="-1"></a>    _rc_ <span class="op">=</span> sqlite3_step<span class="op">(</span>C_stmt<span class="op">);</span></span>
+<span id="cb166-5"><a href="#cb166-5" aria-hidden="true" tabindex="-1"></a>    _C_has_row_ <span class="op">=</span> _rc_ <span class="op">==</span> SQLITE_ROW<span class="op">;</span></span>
+<span id="cb166-6"><a href="#cb166-6" aria-hidden="true" tabindex="-1"></a>    cql_multifetch<span class="op">(</span>_rc_<span class="op">,</span> C_stmt<span class="op">,</span> <span class="dv">2</span><span class="op">,</span></span>
+<span id="cb166-7"><a href="#cb166-7" aria-hidden="true" tabindex="-1"></a>                   CQL_DATA_TYPE_NOT_NULL <span class="op">|</span> CQL_DATA_TYPE_INT32<span class="op">,</span> <span class="op">&amp;</span>x<span class="op">,</span></span>
+<span id="cb166-8"><a href="#cb166-8" aria-hidden="true" tabindex="-1"></a>                   CQL_DATA_TYPE_NOT_NULL <span class="op">|</span> CQL_DATA_TYPE_INT32<span class="op">,</span> <span class="op">&amp;</span>y<span class="op">);</span></span>
+<span id="cb166-9"><a href="#cb166-9" aria-hidden="true" tabindex="-1"></a>    <span class="cf">if</span> <span class="op">(</span>_rc_ <span class="op">!=</span> SQLITE_ROW <span class="op">&amp;&amp;</span> _rc_ <span class="op">!=</span> SQLITE_DONE<span class="op">)</span> <span class="op">{</span> cql_error_trace<span class="op">();</span> <span class="cf">goto</span> cql_cleanup<span class="op">;</span> <span class="op">}</span></span>
+<span id="cb166-10"><a href="#cb166-10" aria-hidden="true" tabindex="-1"></a>  <span class="op">}</span></span></code></pre></div>
+<p>So, if you use the cursors name in an ordinary expression that is converted to a reference to the boolean <code>_C_has_row_</code>. Within the loop we’re going to print some data and then fetch the next row. The internal fetch is of course the same as the first.</p>
+<p>The next improvement that was added to the language was the <code>LOOP</code> statement. Let’s take a look:</p>
+<div class="sourceCode" id="cb167"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb167-1"><a href="#cb167-1" aria-hidden="true" tabindex="-1"></a><span class="cf">BEGIN</span></span>
+<span id="cb167-2"><a href="#cb167-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">DECLARE</span> x <span class="dt">INTEGER</span> <span class="kw">NOT</span> <span class="kw">NULL</span>;</span>
+<span id="cb167-3"><a href="#cb167-3" aria-hidden="true" tabindex="-1"></a>  <span class="kw">DECLARE</span> y <span class="dt">INTEGER</span> <span class="kw">NOT</span> <span class="kw">NULL</span>;</span>
+<span id="cb167-4"><a href="#cb167-4" aria-hidden="true" tabindex="-1"></a>  <span class="kw">DECLARE</span> C <span class="kw">CURSOR</span> <span class="cf">FOR</span> <span class="kw">SELECT</span> <span class="dv">1</span> <span class="kw">AS</span> x, <span class="dv">2</span> <span class="kw">AS</span> y;</span>
+<span id="cb167-5"><a href="#cb167-5" aria-hidden="true" tabindex="-1"></a>  <span class="cf">LOOP</span> FETCH C <span class="kw">INTO</span> x, y</span>
+<span id="cb167-6"><a href="#cb167-6" aria-hidden="true" tabindex="-1"></a>  <span class="cf">BEGIN</span></span>
+<span id="cb167-7"><a href="#cb167-7" aria-hidden="true" tabindex="-1"></a>    <span class="kw">CALL</span> printf(<span class="ot">&quot;%d, %d\n&quot;</span>, x, y);</span>
+<span id="cb167-8"><a href="#cb167-8" aria-hidden="true" tabindex="-1"></a>  <span class="cf">END</span>;</span>
+<span id="cb167-9"><a href="#cb167-9" aria-hidden="true" tabindex="-1"></a><span class="cf">END</span>;</span></code></pre></div>
+<p>The generated code is very similar:</p>
+<div class="sourceCode" id="cb168"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb168-1"><a href="#cb168-1" aria-hidden="true" tabindex="-1"></a>  <span class="cf">for</span> <span class="op">(;;)</span> <span class="op">{</span></span>
+<span id="cb168-2"><a href="#cb168-2" aria-hidden="true" tabindex="-1"></a>    _rc_ <span class="op">=</span> sqlite3_step<span class="op">(</span>C_stmt<span class="op">);</span></span>
+<span id="cb168-3"><a href="#cb168-3" aria-hidden="true" tabindex="-1"></a>    _C_has_row_ <span class="op">=</span> _rc_ <span class="op">==</span> SQLITE_ROW<span class="op">;</span></span>
+<span id="cb168-4"><a href="#cb168-4" aria-hidden="true" tabindex="-1"></a>    cql_multifetch<span class="op">(</span>_rc_<span class="op">,</span> C_stmt<span class="op">,</span> <span class="dv">2</span><span class="op">,</span></span>
+<span id="cb168-5"><a href="#cb168-5" aria-hidden="true" tabindex="-1"></a>                   CQL_DATA_TYPE_NOT_NULL <span class="op">|</span> CQL_DATA_TYPE_INT32<span class="op">,</span> <span class="op">&amp;</span>x<span class="op">,</span></span>
+<span id="cb168-6"><a href="#cb168-6" aria-hidden="true" tabindex="-1"></a>                   CQL_DATA_TYPE_NOT_NULL <span class="op">|</span> CQL_DATA_TYPE_INT32<span class="op">,</span> <span class="op">&amp;</span>y<span class="op">);</span></span>
+<span id="cb168-7"><a href="#cb168-7" aria-hidden="true" tabindex="-1"></a>    <span class="cf">if</span> <span class="op">(</span>_rc_ <span class="op">!=</span> SQLITE_ROW <span class="op">&amp;&amp;</span> _rc_ <span class="op">!=</span> SQLITE_DONE<span class="op">)</span> <span class="op">{</span> cql_error_trace<span class="op">();</span> <span class="cf">goto</span> cql_cleanup<span class="op">;</span> <span class="op">}</span></span>
+<span id="cb168-8"><a href="#cb168-8" aria-hidden="true" tabindex="-1"></a>    <span class="cf">if</span> <span class="op">(!</span>_C_has_row_<span class="op">)</span> <span class="cf">break</span><span class="op">;</span></span>
+<span id="cb168-9"><a href="#cb168-9" aria-hidden="true" tabindex="-1"></a>    printf<span class="op">(</span><span class="st">&quot;%d, %d</span><span class="sc">\n</span><span class="st">&quot;</span><span class="op">,</span> x<span class="op">,</span> y<span class="op">);</span></span>
+<span id="cb168-10"><a href="#cb168-10" aria-hidden="true" tabindex="-1"></a>  <span class="op">}</span></span></code></pre></div>
+<p>This is done by:</p>
+<ul>
+<li>emit the <code>for (;;) {</code> to start the loop</li>
+<li>generate the <code>FETCH</code> just as if it was standalone</li>
+<li>emit <code>if (!_C_has_row_) break;</code> (with the correct cursor name)</li>
+<li>use <code>cg_stmt_list</code> to emit the internal statement list (<code>CALL printf</code> in this case)</li>
+<li>close the loop with <code>}</code> and we’re done</li>
+</ul>
+<h3 id="cursors-with-storage">Cursors With Storage</h3>
+<p>We now come to the big motivating reasons for having the notion of shapes in the CQL langauge. This particular case was the first such example in the language and it’s very commonly used and saves you a lot of typing. Like the other examples it’s only sugar in that it doesn’t give you any new language powers you didn’t have, but it does give clarity and maintenance advantages. And it’s just a lot less to type.</p>
+<p>Let’s go back to one of the earlier examples, but write it the modern way:</p>
+<div class="sourceCode" id="cb169"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb169-1"><a href="#cb169-1" aria-hidden="true" tabindex="-1"></a><span class="kw">CREATE</span> PROC p ()</span>
+<span id="cb169-2"><a href="#cb169-2" aria-hidden="true" tabindex="-1"></a><span class="cf">BEGIN</span></span>
+<span id="cb169-3"><a href="#cb169-3" aria-hidden="true" tabindex="-1"></a>  <span class="kw">DECLARE</span> C <span class="kw">CURSOR</span> <span class="cf">FOR</span> <span class="kw">SELECT</span> <span class="dv">1</span> <span class="kw">AS</span> x, <span class="dv">2</span> <span class="kw">AS</span> y;</span>
+<span id="cb169-4"><a href="#cb169-4" aria-hidden="true" tabindex="-1"></a>  FETCH C;</span>
+<span id="cb169-5"><a href="#cb169-5" aria-hidden="true" tabindex="-1"></a><span class="cf">END</span>;</span></code></pre></div>
+<p>And the generated C code:</p>
+<div class="sourceCode" id="cb170"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb170-1"><a href="#cb170-1" aria-hidden="true" tabindex="-1"></a><span class="kw">typedef</span> <span class="kw">struct</span> p_C_row <span class="op">{</span></span>
+<span id="cb170-2"><a href="#cb170-2" aria-hidden="true" tabindex="-1"></a>  cql_bool _has_row_<span class="op">;</span></span>
+<span id="cb170-3"><a href="#cb170-3" aria-hidden="true" tabindex="-1"></a>  cql_uint16 _refs_count_<span class="op">;</span></span>
+<span id="cb170-4"><a href="#cb170-4" aria-hidden="true" tabindex="-1"></a>  cql_uint16 _refs_offset_<span class="op">;</span></span>
+<span id="cb170-5"><a href="#cb170-5" aria-hidden="true" tabindex="-1"></a>  cql_int32 x<span class="op">;</span></span>
+<span id="cb170-6"><a href="#cb170-6" aria-hidden="true" tabindex="-1"></a>  cql_int32 y<span class="op">;</span></span>
+<span id="cb170-7"><a href="#cb170-7" aria-hidden="true" tabindex="-1"></a><span class="op">}</span> p_C_row<span class="op">;</span></span>
+<span id="cb170-8"><a href="#cb170-8" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb170-9"><a href="#cb170-9" aria-hidden="true" tabindex="-1"></a>CQL_WARN_UNUSED cql_code p<span class="op">(</span>sqlite3 <span class="op">*</span>_Nonnull _db_<span class="op">)</span> <span class="op">{</span></span>
+<span id="cb170-10"><a href="#cb170-10" aria-hidden="true" tabindex="-1"></a>  cql_code _rc_ <span class="op">=</span> SQLITE_OK<span class="op">;</span></span>
+<span id="cb170-11"><a href="#cb170-11" aria-hidden="true" tabindex="-1"></a>  sqlite3_stmt <span class="op">*</span>C_stmt <span class="op">=</span> NULL<span class="op">;</span></span>
+<span id="cb170-12"><a href="#cb170-12" aria-hidden="true" tabindex="-1"></a>  p_C_row C <span class="op">=</span> <span class="op">{</span> <span class="dv">0</span> <span class="op">};</span></span>
+<span id="cb170-13"><a href="#cb170-13" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb170-14"><a href="#cb170-14" aria-hidden="true" tabindex="-1"></a>  _rc_ <span class="op">=</span> cql_prepare<span class="op">(</span>_db_<span class="op">,</span> <span class="op">&amp;</span>C_stmt<span class="op">,</span></span>
+<span id="cb170-15"><a href="#cb170-15" aria-hidden="true" tabindex="-1"></a>    <span class="st">&quot;SELECT 1, 2&quot;</span><span class="op">);</span></span>
+<span id="cb170-16"><a href="#cb170-16" aria-hidden="true" tabindex="-1"></a>  <span class="cf">if</span> <span class="op">(</span>_rc_ <span class="op">!=</span> SQLITE_OK<span class="op">)</span> <span class="op">{</span> cql_error_trace<span class="op">();</span> <span class="cf">goto</span> cql_cleanup<span class="op">;</span> <span class="op">}</span></span>
+<span id="cb170-17"><a href="#cb170-17" aria-hidden="true" tabindex="-1"></a>  _rc_ <span class="op">=</span> sqlite3_step<span class="op">(</span>C_stmt<span class="op">);</span></span>
+<span id="cb170-18"><a href="#cb170-18" aria-hidden="true" tabindex="-1"></a>  C<span class="op">.</span>_has_row_ <span class="op">=</span> _rc_ <span class="op">==</span> SQLITE_ROW<span class="op">;</span></span>
+<span id="cb170-19"><a href="#cb170-19" aria-hidden="true" tabindex="-1"></a>  cql_multifetch<span class="op">(</span>_rc_<span class="op">,</span> C_stmt<span class="op">,</span> <span class="dv">2</span><span class="op">,</span></span>
+<span id="cb170-20"><a href="#cb170-20" aria-hidden="true" tabindex="-1"></a>                 CQL_DATA_TYPE_NOT_NULL <span class="op">|</span> CQL_DATA_TYPE_INT32<span class="op">,</span> <span class="op">&amp;</span>C<span class="op">.</span>x<span class="op">,</span></span>
+<span id="cb170-21"><a href="#cb170-21" aria-hidden="true" tabindex="-1"></a>                 CQL_DATA_TYPE_NOT_NULL <span class="op">|</span> CQL_DATA_TYPE_INT32<span class="op">,</span> <span class="op">&amp;</span>C<span class="op">.</span>y<span class="op">);</span></span>
+<span id="cb170-22"><a href="#cb170-22" aria-hidden="true" tabindex="-1"></a>  <span class="cf">if</span> <span class="op">(</span>_rc_ <span class="op">!=</span> SQLITE_ROW <span class="op">&amp;&amp;</span> _rc_ <span class="op">!=</span> SQLITE_DONE<span class="op">)</span> <span class="op">{</span> cql_error_trace<span class="op">();</span> <span class="cf">goto</span> cql_cleanup<span class="op">;</span> <span class="op">}</span></span>
+<span id="cb170-23"><a href="#cb170-23" aria-hidden="true" tabindex="-1"></a>  _rc_ <span class="op">=</span> SQLITE_OK<span class="op">;</span></span>
+<span id="cb170-24"><a href="#cb170-24" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb170-25"><a href="#cb170-25" aria-hidden="true" tabindex="-1"></a>cql_cleanup<span class="op">:</span></span>
+<span id="cb170-26"><a href="#cb170-26" aria-hidden="true" tabindex="-1"></a>  cql_finalize_stmt<span class="op">(&amp;</span>C_stmt<span class="op">);</span></span>
+<span id="cb170-27"><a href="#cb170-27" aria-hidden="true" tabindex="-1"></a>  <span class="cf">return</span> _rc_<span class="op">;</span></span>
+<span id="cb170-28"><a href="#cb170-28" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span></code></pre></div>
+<p>Let’s look at what’s different here:</p>
+<ul>
+<li><code>struct p_C_row</code> has been created, it contains:
+<ul>
+<li><code>_has_row_</code> for the cursor</li>
+<li><code>x</code> and <code>y</code> the data fields</li>
+<li><code>_refs_count</code> the number of reference fields in the cursor (0 in this case)</li>
+<li><code>_refs_offset</code> the offset of the references fields (they always go at the end)</li>
+<li>because the references are together a cursor with lots of reference fields can be cleaned up easily</li>
+</ul></li>
+<li>in the generated code the variable <code>C</code> refers to the current data that has been fetched
+<ul>
+<li>convenient for debugging <code>p C</code> in lldb shows you the row</li>
+</ul></li>
+<li>references to <code>x</code> and <code>y</code> became <code>C.x</code> and <code>C.y</code></li>
+<li>references to <code>_C_has_row_</code> became <code>C._has_row_</code></li>
+</ul>
+<p>That’s pretty much it. The beauty of this is that you can’t get the declarations of your locals wrong and you don’t have to list them all no matter how big the data is. If the data shape changes the cursor change automatically changes to accomodate it. Everything is still statically typed.</p>
+<p>Now lets look at the loop pattern:</p>
+<div class="sourceCode" id="cb171"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb171-1"><a href="#cb171-1" aria-hidden="true" tabindex="-1"></a><span class="kw">CREATE</span> PROC p ()</span>
+<span id="cb171-2"><a href="#cb171-2" aria-hidden="true" tabindex="-1"></a><span class="cf">BEGIN</span></span>
+<span id="cb171-3"><a href="#cb171-3" aria-hidden="true" tabindex="-1"></a>  <span class="kw">DECLARE</span> C <span class="kw">CURSOR</span> <span class="cf">FOR</span> <span class="kw">SELECT</span> <span class="dv">1</span> <span class="kw">AS</span> x, <span class="dv">2</span> <span class="kw">AS</span> y;</span>
+<span id="cb171-4"><a href="#cb171-4" aria-hidden="true" tabindex="-1"></a>  <span class="cf">LOOP</span> FETCH C</span>
+<span id="cb171-5"><a href="#cb171-5" aria-hidden="true" tabindex="-1"></a>  <span class="cf">BEGIN</span></span>
+<span id="cb171-6"><a href="#cb171-6" aria-hidden="true" tabindex="-1"></a>    <span class="kw">CALL</span> printf(<span class="ot">&quot;%d, %d\n&quot;</span>, C.x, C.y);</span>
+<span id="cb171-7"><a href="#cb171-7" aria-hidden="true" tabindex="-1"></a>  <span class="cf">END</span>;</span>
+<span id="cb171-8"><a href="#cb171-8" aria-hidden="true" tabindex="-1"></a><span class="cf">END</span>;</span></code></pre></div>
+<p>Note that the columns of the cursor were defined by the column aliases of the <code>SELECT</code>.</p>
+<div class="sourceCode" id="cb172"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb172-1"><a href="#cb172-1" aria-hidden="true" tabindex="-1"></a>  <span class="cf">for</span> <span class="op">(;;)</span> <span class="op">{</span></span>
+<span id="cb172-2"><a href="#cb172-2" aria-hidden="true" tabindex="-1"></a>    _rc_ <span class="op">=</span> sqlite3_step<span class="op">(</span>C_stmt<span class="op">);</span></span>
+<span id="cb172-3"><a href="#cb172-3" aria-hidden="true" tabindex="-1"></a>    C<span class="op">.</span>_has_row_ <span class="op">=</span> _rc_ <span class="op">==</span> SQLITE_ROW<span class="op">;</span></span>
+<span id="cb172-4"><a href="#cb172-4" aria-hidden="true" tabindex="-1"></a>    cql_multifetch<span class="op">(</span>_rc_<span class="op">,</span> C_stmt<span class="op">,</span> <span class="dv">2</span><span class="op">,</span></span>
+<span id="cb172-5"><a href="#cb172-5" aria-hidden="true" tabindex="-1"></a>                   CQL_DATA_TYPE_NOT_NULL <span class="op">|</span> CQL_DATA_TYPE_INT32<span class="op">,</span> <span class="op">&amp;</span>C<span class="op">.</span>x<span class="op">,</span></span>
+<span id="cb172-6"><a href="#cb172-6" aria-hidden="true" tabindex="-1"></a>                   CQL_DATA_TYPE_NOT_NULL <span class="op">|</span> CQL_DATA_TYPE_INT32<span class="op">,</span> <span class="op">&amp;</span>C<span class="op">.</span>y<span class="op">);</span></span>
+<span id="cb172-7"><a href="#cb172-7" aria-hidden="true" tabindex="-1"></a>    <span class="cf">if</span> <span class="op">(</span>_rc_ <span class="op">!=</span> SQLITE_ROW <span class="op">&amp;&amp;</span> _rc_ <span class="op">!=</span> SQLITE_DONE<span class="op">)</span> <span class="op">{</span> cql_error_trace<span class="op">();</span> <span class="cf">goto</span> cql_cleanup<span class="op">;</span> <span class="op">}</span></span>
+<span id="cb172-8"><a href="#cb172-8" aria-hidden="true" tabindex="-1"></a>    <span class="cf">if</span> <span class="op">(!</span>C<span class="op">.</span>_has_row_<span class="op">)</span> <span class="cf">break</span><span class="op">;</span></span>
+<span id="cb172-9"><a href="#cb172-9" aria-hidden="true" tabindex="-1"></a>    printf<span class="op">(</span><span class="st">&quot;%d, %d</span><span class="sc">\n</span><span class="st">&quot;</span><span class="op">,</span> C<span class="op">.</span>x<span class="op">,</span> C<span class="op">.</span>y<span class="op">);</span></span>
+<span id="cb172-10"><a href="#cb172-10" aria-hidden="true" tabindex="-1"></a>  <span class="op">}</span></span></code></pre></div>
+<p>The loop is basically the same except <code>x</code> and <code>y</code> have been replaced with <code>C.x</code> and <code>C.y</code> and again <code>_C_has_row_</code> is now <code>C._has_row_</code>.</p>
+<p>The code generator knows that it should allocate storage for the <code>C</code> cursor if it has the flag <code>SEM_TYPE_HAS_SHAPE_STORAGE</code> on it. The semantic analyzer adds that flag if it ever finds <code>FETCH C</code> with no <code>INTO</code> part.</p>
+<p>Finally let’s look at an example with cleanup required. We’ll just change the test case a tiny bit.</p>
+<div class="sourceCode" id="cb173"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb173-1"><a href="#cb173-1" aria-hidden="true" tabindex="-1"></a><span class="kw">CREATE</span> PROC p ()</span>
+<span id="cb173-2"><a href="#cb173-2" aria-hidden="true" tabindex="-1"></a><span class="cf">BEGIN</span></span>
+<span id="cb173-3"><a href="#cb173-3" aria-hidden="true" tabindex="-1"></a>  <span class="kw">DECLARE</span> C <span class="kw">CURSOR</span> <span class="cf">FOR</span> <span class="kw">SELECT</span> <span class="dv">1</span> <span class="kw">AS</span> x, <span class="ot">&quot;2&quot;</span> <span class="kw">AS</span> y;</span>
+<span id="cb173-4"><a href="#cb173-4" aria-hidden="true" tabindex="-1"></a>  <span class="cf">LOOP</span> FETCH C</span>
+<span id="cb173-5"><a href="#cb173-5" aria-hidden="true" tabindex="-1"></a>  <span class="cf">BEGIN</span></span>
+<span id="cb173-6"><a href="#cb173-6" aria-hidden="true" tabindex="-1"></a>    <span class="kw">CALL</span> printf(<span class="ot">&quot;%d, %s\n&quot;</span>, C.x, C.y);</span>
+<span id="cb173-7"><a href="#cb173-7" aria-hidden="true" tabindex="-1"></a>  <span class="cf">END</span>;</span>
+<span id="cb173-8"><a href="#cb173-8" aria-hidden="true" tabindex="-1"></a><span class="cf">END</span>;</span></code></pre></div>
+<p>The <code>x</code> column is now text. We’ll get this code which will be studied below:</p>
+<pre><code>typedef struct p_C_row {
+  cql_bool _has_row_;
+  cql_uint16 _refs_count_;
+  cql_uint16 _refs_offset_;
+  cql_int32 y;
+  cql_string_ref _Nonnull x;
+} p_C_row;
+
+#define p_C_refs_offset cql_offsetof(p_C_row, x) // count = 1
+
+CQL_WARN_UNUSED cql_code p(sqlite3 *_Nonnull _db_) {
+  cql_code _rc_ = SQLITE_OK;
+  sqlite3_stmt *C_stmt = NULL;
+  p_C_row C = { ._refs_count_ = 1, ._refs_offset_ = p_C_refs_offset };
+
+  _rc_ = cql_prepare(_db_, &amp;C_stmt,
+    &quot;SELECT &#39;1&#39;, 2&quot;);
+  if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
+  for (;;) {
+    _rc_ = sqlite3_step(C_stmt);
+    C._has_row_ = _rc_ == SQLITE_ROW;
+    cql_multifetch(_rc_, C_stmt, 2,
+                   CQL_DATA_TYPE_NOT_NULL | CQL_DATA_TYPE_STRING, &amp;C.x,
+                   CQL_DATA_TYPE_NOT_NULL | CQL_DATA_TYPE_INT32, &amp;C.y);
+    if (_rc_ != SQLITE_ROW &amp;&amp; _rc_ != SQLITE_DONE) { cql_error_trace(); goto cql_cleanup; }
+    if (!C._has_row_) break;
+    cql_alloc_cstr(_cstr_1, C.x);
+    printf(&quot;%s, %d\n&quot;, _cstr_1, C.y);
+    cql_free_cstr(_cstr_1, C.x);
+  }
+  _rc_ = SQLITE_OK;
+
+cql_cleanup:
+  cql_finalize_stmt(&amp;C_stmt);
+  cql_teardown_row(C);
+  return _rc_;
+}</code></pre>
+<p>It’s very similar to what we had before, let’s quickly review the differences.</p>
+<div class="sourceCode" id="cb175"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb175-1"><a href="#cb175-1" aria-hidden="true" tabindex="-1"></a><span class="kw">typedef</span> <span class="kw">struct</span> p_C_row <span class="op">{</span></span>
+<span id="cb175-2"><a href="#cb175-2" aria-hidden="true" tabindex="-1"></a>  cql_bool _has_row_<span class="op">;</span></span>
+<span id="cb175-3"><a href="#cb175-3" aria-hidden="true" tabindex="-1"></a>  cql_uint16 _refs_count_<span class="op">;</span></span>
+<span id="cb175-4"><a href="#cb175-4" aria-hidden="true" tabindex="-1"></a>  cql_uint16 _refs_offset_<span class="op">;</span></span>
+<span id="cb175-5"><a href="#cb175-5" aria-hidden="true" tabindex="-1"></a>  cql_int32 y<span class="op">;</span></span>
+<span id="cb175-6"><a href="#cb175-6" aria-hidden="true" tabindex="-1"></a>  cql_string_ref _Nonnull x<span class="op">;</span></span>
+<span id="cb175-7"><a href="#cb175-7" aria-hidden="true" tabindex="-1"></a><span class="op">}</span> p_C_row<span class="op">;</span></span>
+<span id="cb175-8"><a href="#cb175-8" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb175-9"><a href="#cb175-9" aria-hidden="true" tabindex="-1"></a><span class="pp">#define p_C_refs_offset cql_offsetof(p_C_row, x) </span><span class="co">// count = 1</span></span></code></pre></div>
+<ul>
+<li><code>x</code> is now <code>cql_string_ref _Nonnull x;</code> rather than <code>cql_int32</code></li>
+<li><code>x</code> has moved to the end (because it’s a reference type)</li>
+<li>the offset of the first ref is computed in a constant</li>
+</ul>
+<p>Recall the reference types are always at the end and together.</p>
+<div class="sourceCode" id="cb176"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb176-1"><a href="#cb176-1" aria-hidden="true" tabindex="-1"></a>  p_C_row C <span class="op">=</span> <span class="op">{</span> <span class="op">.</span>_refs_count_ <span class="op">=</span> <span class="dv">1</span><span class="op">,</span> <span class="op">.</span>_refs_offset_ <span class="op">=</span> p_C_refs_offset <span class="op">};</span></span></code></pre></div>
+<ul>
+<li><code>p_C_row</code> is now initialized to to ref count 1 and refs offset <code>p_C_refs_offset</code> defined above</li>
+</ul>
+<div class="sourceCode" id="cb177"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb177-1"><a href="#cb177-1" aria-hidden="true" tabindex="-1"></a>  cql_multifetch<span class="op">(</span>_rc_<span class="op">,</span> C_stmt<span class="op">,</span> <span class="dv">2</span><span class="op">,</span></span>
+<span id="cb177-2"><a href="#cb177-2" aria-hidden="true" tabindex="-1"></a>                 CQL_DATA_TYPE_NOT_NULL <span class="op">|</span> CQL_DATA_TYPE_STRING<span class="op">,</span> <span class="op">&amp;</span>C<span class="op">.</span>x<span class="op">,</span></span>
+<span id="cb177-3"><a href="#cb177-3" aria-hidden="true" tabindex="-1"></a>                 CQL_DATA_TYPE_NOT_NULL <span class="op">|</span> CQL_DATA_TYPE_INT32<span class="op">,</span> <span class="op">&amp;</span>C<span class="op">.</span>y<span class="op">);</span></span></code></pre></div>
+<ul>
+<li>C.x is now of type string</li>
+</ul>
+<div class="sourceCode" id="cb178"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb178-1"><a href="#cb178-1" aria-hidden="true" tabindex="-1"></a>    cql_alloc_cstr<span class="op">(</span>_cstr_1<span class="op">,</span> C<span class="op">.</span>x<span class="op">);</span></span>
+<span id="cb178-2"><a href="#cb178-2" aria-hidden="true" tabindex="-1"></a>    printf<span class="op">(</span><span class="st">&quot;%s, %d</span><span class="sc">\n</span><span class="st">&quot;</span><span class="op">,</span> _cstr_1<span class="op">,</span> C<span class="op">.</span>y<span class="op">);</span></span>
+<span id="cb178-3"><a href="#cb178-3" aria-hidden="true" tabindex="-1"></a>    cql_free_cstr<span class="op">(</span>_cstr_1<span class="op">,</span> C<span class="op">.</span>x<span class="op">);</span></span></code></pre></div>
+<ul>
+<li>C.x has to be converted to a C style string before it can be used with <code>printf</code> as a <code>%s</code> argument</li>
+</ul>
+<div class="sourceCode" id="cb179"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb179-1"><a href="#cb179-1" aria-hidden="true" tabindex="-1"></a>  cql_teardown_row<span class="op">(</span>C<span class="op">);</span></span></code></pre></div>
+<ul>
+<li>the cleanup section has to include code to teardown the cursor, this will release all of its reference variables in bulk
+<ul>
+<li>remember we know the count, and the offset of the first one – that’s all we need to do them all</li>
+</ul></li>
+</ul>
+<p>With these primitives we can easily create cursors of any shape and load them up with data. We don’t have to redundantly declare locals that match the shape of our select statements which is both error prone and a hassle.</p>
+<p>All of this is actually very easy for the code-generator. The semantic analysis phase knows if the cursor needs shape storage. And it also recognizes when a variable reference like <code>C.x</code> happens, the variable references are re-written in the AST so that the code-generator doesn’t even have to know there was a cursor reference, from its perspective the variable IS <code>C.x</code> (which it sort of is). The code generator does have to create the storage for the cursor but it knows it should do so because the cursor variable is marked with <code>SEM_TYPE_HAS_SHAPE_STORAGE</code>. A cursor without this marking only gets its statement (but not always as we’ll see later) and its <code>_cursor_has_row_</code> hidden variable.</p>
+<h3 id="flowing-sqlite-statements-between-procedures">Flowing SQLite Statements Between Procedures</h3>
+<p>Earlier we saw that we can get a cursor from a SQLite <code>SELECT</code> statement. The cursor is used to iterate over the <code>sqlite3_stmt *</code> that SQLite provides to us. This process can be done between procedures. Here’s a simple example:</p>
+<div class="sourceCode" id="cb180"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb180-1"><a href="#cb180-1" aria-hidden="true" tabindex="-1"></a><span class="ot">@ATTRIBUTE(cql:private)</span></span>
+<span id="cb180-2"><a href="#cb180-2" aria-hidden="true" tabindex="-1"></a><span class="kw">CREATE</span> PROC q ()</span>
+<span id="cb180-3"><a href="#cb180-3" aria-hidden="true" tabindex="-1"></a><span class="cf">BEGIN</span></span>
+<span id="cb180-4"><a href="#cb180-4" aria-hidden="true" tabindex="-1"></a>  <span class="kw">SELECT</span> <span class="ot">&quot;1&quot;</span> <span class="kw">AS</span> x, <span class="dv">2</span> <span class="kw">AS</span> y;</span>
+<span id="cb180-5"><a href="#cb180-5" aria-hidden="true" tabindex="-1"></a><span class="cf">END</span>;</span></code></pre></div>
+<p>This is the first example of a procedure that return a result set that we’ve seen. The wiring for this is very simple.</p>
+<div class="sourceCode" id="cb181"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb181-1"><a href="#cb181-1" aria-hidden="true" tabindex="-1"></a><span class="dt">static</span> CQL_WARN_UNUSED cql_code q<span class="op">(</span></span>
+<span id="cb181-2"><a href="#cb181-2" aria-hidden="true" tabindex="-1"></a>  sqlite3 <span class="op">*</span>_Nonnull _db_<span class="op">,</span></span>
+<span id="cb181-3"><a href="#cb181-3" aria-hidden="true" tabindex="-1"></a>  sqlite3_stmt <span class="op">*</span>_Nullable <span class="op">*</span>_Nonnull _result_stmt<span class="op">)</span></span>
+<span id="cb181-4"><a href="#cb181-4" aria-hidden="true" tabindex="-1"></a><span class="op">{</span></span>
+<span id="cb181-5"><a href="#cb181-5" aria-hidden="true" tabindex="-1"></a>  cql_code _rc_ <span class="op">=</span> SQLITE_OK<span class="op">;</span></span>
+<span id="cb181-6"><a href="#cb181-6" aria-hidden="true" tabindex="-1"></a>  <span class="op">*</span>_result_stmt <span class="op">=</span> NULL<span class="op">;</span></span>
+<span id="cb181-7"><a href="#cb181-7" aria-hidden="true" tabindex="-1"></a>  _rc_ <span class="op">=</span> cql_prepare<span class="op">(</span>_db_<span class="op">,</span> _result_stmt<span class="op">,</span></span>
+<span id="cb181-8"><a href="#cb181-8" aria-hidden="true" tabindex="-1"></a>    <span class="st">&quot;SELECT &#39;1&#39;, 2&quot;</span><span class="op">);</span></span>
+<span id="cb181-9"><a href="#cb181-9" aria-hidden="true" tabindex="-1"></a>  <span class="cf">if</span> <span class="op">(</span>_rc_ <span class="op">!=</span> SQLITE_OK<span class="op">)</span> <span class="op">{</span> cql_error_trace<span class="op">();</span> <span class="cf">goto</span> cql_cleanup<span class="op">;</span> <span class="op">}</span></span>
+<span id="cb181-10"><a href="#cb181-10" aria-hidden="true" tabindex="-1"></a>  _rc_ <span class="op">=</span> SQLITE_OK<span class="op">;</span></span>
+<span id="cb181-11"><a href="#cb181-11" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb181-12"><a href="#cb181-12" aria-hidden="true" tabindex="-1"></a>cql_cleanup<span class="op">:</span></span>
+<span id="cb181-13"><a href="#cb181-13" aria-hidden="true" tabindex="-1"></a>  <span class="cf">if</span> <span class="op">(</span>_rc_ <span class="op">==</span> SQLITE_OK <span class="op">&amp;&amp;</span> <span class="op">!*</span>_result_stmt<span class="op">)</span> _rc_ <span class="op">=</span> cql_no_rows_stmt<span class="op">(</span>_db_<span class="op">,</span> _result_stmt<span class="op">);</span></span>
+<span id="cb181-14"><a href="#cb181-14" aria-hidden="true" tabindex="-1"></a>  <span class="cf">return</span> _rc_<span class="op">;</span></span>
+<span id="cb181-15"><a href="#cb181-15" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span></code></pre></div>
+<p>First note that there are now <em>two</em> hidden parameters to <code>q</code>:</p>
+<ul>
+<li><code>_db_</code> : the database pointer as usual,</li>
+<li><code>_result_stmt</code> : the statement produced by this procedure</li>
+</ul>
+<p>The rest of the code is just like any other bound SQL statement. Note that if <code>_result_stmt</code> isn’t otherwise set by the code it will be initialized to a statement that will return zero rows.</p>
+<p>All of this is pretty much old news except for the new hidden variable. Note let’s look how we might use this. We can write a procedure that calls <code>q</code>, like so:</p>
+<div class="sourceCode" id="cb182"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb182-1"><a href="#cb182-1" aria-hidden="true" tabindex="-1"></a><span class="kw">CREATE</span> PROC p ()</span>
+<span id="cb182-2"><a href="#cb182-2" aria-hidden="true" tabindex="-1"></a><span class="cf">BEGIN</span></span>
+<span id="cb182-3"><a href="#cb182-3" aria-hidden="true" tabindex="-1"></a>  <span class="kw">DECLARE</span> C <span class="kw">CURSOR</span> <span class="cf">FOR</span> <span class="kw">CALL</span> q();</span>
+<span id="cb182-4"><a href="#cb182-4" aria-hidden="true" tabindex="-1"></a>  FETCH C;</span>
+<span id="cb182-5"><a href="#cb182-5" aria-hidden="true" tabindex="-1"></a><span class="cf">END</span>;</span></code></pre></div>
+<p>This generates:</p>
+<div class="sourceCode" id="cb183"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb183-1"><a href="#cb183-1" aria-hidden="true" tabindex="-1"></a>CQL_WARN_UNUSED cql_code p<span class="op">(</span>sqlite3 <span class="op">*</span>_Nonnull _db_<span class="op">)</span> <span class="op">{</span></span>
+<span id="cb183-2"><a href="#cb183-2" aria-hidden="true" tabindex="-1"></a>  cql_code _rc_ <span class="op">=</span> SQLITE_OK<span class="op">;</span></span>
+<span id="cb183-3"><a href="#cb183-3" aria-hidden="true" tabindex="-1"></a>  sqlite3_stmt <span class="op">*</span>C_stmt <span class="op">=</span> NULL<span class="op">;</span></span>
+<span id="cb183-4"><a href="#cb183-4" aria-hidden="true" tabindex="-1"></a>  p_C_row C <span class="op">=</span> <span class="op">{</span> <span class="op">.</span>_refs_count_ <span class="op">=</span> <span class="dv">1</span><span class="op">,</span> <span class="op">.</span>_refs_offset_ <span class="op">=</span> p_C_refs_offset <span class="op">};</span></span>
+<span id="cb183-5"><a href="#cb183-5" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb183-6"><a href="#cb183-6" aria-hidden="true" tabindex="-1"></a>  _rc_ <span class="op">=</span> q<span class="op">(</span>_db_<span class="op">,</span> <span class="op">&amp;</span>C_stmt<span class="op">);</span></span>
+<span id="cb183-7"><a href="#cb183-7" aria-hidden="true" tabindex="-1"></a>  <span class="cf">if</span> <span class="op">(</span>_rc_ <span class="op">!=</span> SQLITE_OK<span class="op">)</span> <span class="op">{</span> cql_error_trace<span class="op">();</span> <span class="cf">goto</span> cql_cleanup<span class="op">;</span> <span class="op">}</span></span>
+<span id="cb183-8"><a href="#cb183-8" aria-hidden="true" tabindex="-1"></a>  _rc_ <span class="op">=</span> sqlite3_step<span class="op">(</span>C_stmt<span class="op">);</span></span>
+<span id="cb183-9"><a href="#cb183-9" aria-hidden="true" tabindex="-1"></a>  C<span class="op">.</span>_has_row_ <span class="op">=</span> _rc_ <span class="op">==</span> SQLITE_ROW<span class="op">;</span></span>
+<span id="cb183-10"><a href="#cb183-10" aria-hidden="true" tabindex="-1"></a>  cql_multifetch<span class="op">(</span>_rc_<span class="op">,</span> C_stmt<span class="op">,</span> <span class="dv">2</span><span class="op">,</span></span>
+<span id="cb183-11"><a href="#cb183-11" aria-hidden="true" tabindex="-1"></a>                 CQL_DATA_TYPE_NOT_NULL <span class="op">|</span> CQL_DATA_TYPE_STRING<span class="op">,</span> <span class="op">&amp;</span>C<span class="op">.</span>x<span class="op">,</span></span>
+<span id="cb183-12"><a href="#cb183-12" aria-hidden="true" tabindex="-1"></a>                 CQL_DATA_TYPE_NOT_NULL <span class="op">|</span> CQL_DATA_TYPE_INT32<span class="op">,</span> <span class="op">&amp;</span>C<span class="op">.</span>y<span class="op">);</span></span>
+<span id="cb183-13"><a href="#cb183-13" aria-hidden="true" tabindex="-1"></a>  <span class="cf">if</span> <span class="op">(</span>_rc_ <span class="op">!=</span> SQLITE_ROW <span class="op">&amp;&amp;</span> _rc_ <span class="op">!=</span> SQLITE_DONE<span class="op">)</span> <span class="op">{</span> cql_error_trace<span class="op">();</span> <span class="cf">goto</span> cql_cleanup<span class="op">;</span> <span class="op">}</span></span>
+<span id="cb183-14"><a href="#cb183-14" aria-hidden="true" tabindex="-1"></a>  _rc_ <span class="op">=</span> SQLITE_OK<span class="op">;</span></span>
+<span id="cb183-15"><a href="#cb183-15" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb183-16"><a href="#cb183-16" aria-hidden="true" tabindex="-1"></a>cql_cleanup<span class="op">:</span></span>
+<span id="cb183-17"><a href="#cb183-17" aria-hidden="true" tabindex="-1"></a>  cql_finalize_stmt<span class="op">(&amp;</span>C_stmt<span class="op">);</span></span>
+<span id="cb183-18"><a href="#cb183-18" aria-hidden="true" tabindex="-1"></a>  cql_teardown_row<span class="op">(</span>C<span class="op">);</span></span>
+<span id="cb183-19"><a href="#cb183-19" aria-hidden="true" tabindex="-1"></a>  <span class="cf">return</span> _rc_<span class="op">;</span></span>
+<span id="cb183-20"><a href="#cb183-20" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span></code></pre></div>
+<p>All of the above is <em>exactly</em> the same as the previous cases where we got data from the database except that instead of using <code>cql_prepare</code> the compiler produced <code>_rc_ = q(_db_, &amp;C_stmt);</code> That function call gives us, of course, a ready-to-use <code>sqlite3_stmt *</code> which we can then step, and use to fetch values. The shape of the cursor <code>C</code> is determined by the result type of procedure <code>q</code> – hence they always match.</p>
+<p>If q was in some other module, it could be declared with:</p>
+<div class="sourceCode" id="cb184"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb184-1"><a href="#cb184-1" aria-hidden="true" tabindex="-1"></a><span class="kw">DECLARE</span> PROC q () (x TEXT <span class="kw">NOT</span> <span class="kw">NULL</span>, y <span class="dt">INTEGER</span> <span class="kw">NOT</span> <span class="kw">NULL</span>);</span></code></pre></div>
+<p>This is a procedure that takes no arguments and returns a result with the indicated shape.</p>
+<p>CQL can generate this declaration for you if you add <code>--generate_exports</code> to the command line. Note that in this case <code>q</code> was marked with <code>@attribute(cql:private)</code> which caused <code>q</code> to be <code>static</code> in the output. Hence it can’t be called outside this translation unit and <code>--generate_exports</code> won’t provide the declaration.</p>
+<p>If the private annotation were removed, the full exports for this file would be:</p>
+<div class="sourceCode" id="cb185"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb185-1"><a href="#cb185-1" aria-hidden="true" tabindex="-1"></a><span class="kw">DECLARE</span> PROC q () (x TEXT <span class="kw">NOT</span> <span class="kw">NULL</span>, y <span class="dt">INTEGER</span> <span class="kw">NOT</span> <span class="kw">NULL</span>);</span>
+<span id="cb185-2"><a href="#cb185-2" aria-hidden="true" tabindex="-1"></a><span class="kw">DECLARE</span> PROC p () <span class="kw">USING</span> <span class="kw">TRANSACTION</span>;</span></code></pre></div>
+<p>And these would allow calling both procedures from elsewhere. Simply <code>#include</code> the exports file.</p>
+<p>There is a special function in the echoing code that can emit a procedure that was created in the form that is needed to declare it, this is <code>gen_declare_proc_from_create_proc</code>.</p>
+<h3 id="value-cursors">Value Cursors</h3>
+<p>Once CQL had the ability to fetch rows into a cursor with no need to declare all the locals it was clear that it could benefit from the ability to save a copy of any given row. That is basic cursor operations seemed like they should be part of the calculus of CQL. Here’s a simple sample program that illustrates this.</p>
+<div class="sourceCode" id="cb186"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb186-1"><a href="#cb186-1" aria-hidden="true" tabindex="-1"></a><span class="kw">CREATE</span> PROC p ()</span>
+<span id="cb186-2"><a href="#cb186-2" aria-hidden="true" tabindex="-1"></a><span class="cf">BEGIN</span></span>
+<span id="cb186-3"><a href="#cb186-3" aria-hidden="true" tabindex="-1"></a>  <span class="kw">DECLARE</span> C <span class="kw">CURSOR</span> <span class="cf">FOR</span> <span class="kw">SELECT</span> <span class="ot">&quot;1&quot;</span> <span class="kw">AS</span> x, <span class="dv">2</span> <span class="kw">AS</span> y;</span>
+<span id="cb186-4"><a href="#cb186-4" aria-hidden="true" tabindex="-1"></a>  FETCH C;</span>
+<span id="cb186-5"><a href="#cb186-5" aria-hidden="true" tabindex="-1"></a>  <span class="kw">DECLARE</span> D <span class="kw">CURSOR</span> <span class="kw">LIKE</span> C;</span>
+<span id="cb186-6"><a href="#cb186-6" aria-hidden="true" tabindex="-1"></a>  FETCH D <span class="kw">from</span> C;</span>
+<span id="cb186-7"><a href="#cb186-7" aria-hidden="true" tabindex="-1"></a><span class="cf">END</span>;</span></code></pre></div>
+<p>We already have a good idea what is going to happen with <code>C</code> in this program. Let’s look at the generated code focusing just on the parts that involve <code>D</code>.</p>
+<p>First there is a row defintion for <code>D</code>. Unsurprisingly it is exactly the samea as the one for <code>C</code>. This must be the case since we specified <code>D CURSOR LIKE C</code>.</p>
+<div class="sourceCode" id="cb187"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb187-1"><a href="#cb187-1" aria-hidden="true" tabindex="-1"></a><span class="kw">typedef</span> <span class="kw">struct</span> p_D_row <span class="op">{</span></span>
+<span id="cb187-2"><a href="#cb187-2" aria-hidden="true" tabindex="-1"></a>  cql_bool _has_row_<span class="op">;</span></span>
+<span id="cb187-3"><a href="#cb187-3" aria-hidden="true" tabindex="-1"></a>  cql_uint16 _refs_count_<span class="op">;</span></span>
+<span id="cb187-4"><a href="#cb187-4" aria-hidden="true" tabindex="-1"></a>  cql_uint16 _refs_offset_<span class="op">;</span></span>
+<span id="cb187-5"><a href="#cb187-5" aria-hidden="true" tabindex="-1"></a>  cql_int32 y<span class="op">;</span></span>
+<span id="cb187-6"><a href="#cb187-6" aria-hidden="true" tabindex="-1"></a>  cql_string_ref _Nonnull x<span class="op">;</span></span>
+<span id="cb187-7"><a href="#cb187-7" aria-hidden="true" tabindex="-1"></a><span class="op">}</span> p_D_row<span class="op">;</span></span>
+<span id="cb187-8"><a href="#cb187-8" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb187-9"><a href="#cb187-9" aria-hidden="true" tabindex="-1"></a><span class="pp">#define p_D_refs_offset cql_offsetof(p_D_row, x) </span><span class="co">// count = 1</span></span></code></pre></div>
+<p>Then the <code>D</code> cursor variables will be needed:</p>
+<div class="sourceCode" id="cb188"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb188-1"><a href="#cb188-1" aria-hidden="true" tabindex="-1"></a>p_D_row D <span class="op">=</span> <span class="op">{</span> <span class="op">.</span>_refs_count_ <span class="op">=</span> <span class="dv">1</span><span class="op">,</span> <span class="op">.</span>_refs_offset_ <span class="op">=</span> p_D_refs_offset <span class="op">};</span></span></code></pre></div>
+<p>The above also implies the cleanup code:</p>
+<div class="sourceCode" id="cb189"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb189-1"><a href="#cb189-1" aria-hidden="true" tabindex="-1"></a>  cql_teardown_row<span class="op">(</span>D<span class="op">);</span></span></code></pre></div>
+<p>finally, we fetch <code>D</code> from <code>C</code>. That’s just some assignments:</p>
+<div class="sourceCode" id="cb190"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb190-1"><a href="#cb190-1" aria-hidden="true" tabindex="-1"></a>  D<span class="op">.</span>_has_row_ <span class="op">=</span> <span class="dv">1</span><span class="op">;</span></span>
+<span id="cb190-2"><a href="#cb190-2" aria-hidden="true" tabindex="-1"></a>  cql_set_string_ref<span class="op">(&amp;</span>D<span class="op">.</span>x<span class="op">,</span> C<span class="op">.</span>x<span class="op">);</span></span>
+<span id="cb190-3"><a href="#cb190-3" aria-hidden="true" tabindex="-1"></a>  D<span class="op">.</span>y <span class="op">=</span> C<span class="op">.</span>y<span class="op">;</span></span></code></pre></div>
+<p>Importantly, there is no <code>D_stmt</code> variable. <code>D</code> is <em>not</em> a statement cursor like <code>C</code>, it’s a so-called “value” cursor. In that it can only hold values.</p>
+<p>A value cursor can actually be loaded from anywhere, it just holds data. You don’t loop over it (attempts to do so will result in errors).</p>
+<p>The general syntax for loading such a cursor is something like this:</p>
+<div class="sourceCode" id="cb191"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb191-1"><a href="#cb191-1" aria-hidden="true" tabindex="-1"></a> FETCH D(x, y) <span class="kw">FROM</span> <span class="kw">VALUES</span>(C.x, C.y);</span></code></pre></div>
+<p>And indeed the form <code>FETCH D FROM C</code> was rewritten automatically into the general form. The short form is just sugar.</p>
+<p>Once loaded, <code>D.x</code> and <code>D.y</code> can be used as always. The data type of <code>D</code> is similar to <code>C</code>.</p>
+<p>The AST would report:</p>
+<pre><code>{declare_cursor_like_name}: D: select: { x: text notnull, y: integer notnull }
+   variable shape_storage value_cursor</code></pre>
+<p>meaning <code>D</code> has the flags <code>SEM_TYPE_STRUCT</code>, <code>SEM_TYPE_VARIABLE</code>, <code>SEM_TYPE_HAS_SHAPE_STORAGE</code>, and <code>SEM_TYPE_VALUE_CURSOR</code>. That last flag indicates that there is no statement for this cursor, it’s just values. And all such cursors must have <code>SEM_TYPE_HAS_SHAPE_STORAGE</code> – if they had no statement and no storage they would be – nothing.</p>
+<p>Value cursors are enormously helpful and there is sugar for loading them from all kinds of sources with a shape. These forms are described more properly in <a href="https://cgsql.dev/cql-guide/ch05">Chapter 5</a> of the Guide but they all end up going through the general form, making the codegen considerably simpler. There are many examples where the semantic analyzer rewrites a sugar form to a canonical form to keep the codegen from forking into dozens of special cases and most of them have to do with shapes and cursors.</p>
+<h3 id="returning-value-cursors">Returning Value Cursors</h3>
+<p>Let’s look at an example that is similar to the previous one:</p>
+<div class="sourceCode" id="cb193"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb193-1"><a href="#cb193-1" aria-hidden="true" tabindex="-1"></a><span class="ot">@ATTRIBUTE(cql:private)</span></span>
+<span id="cb193-2"><a href="#cb193-2" aria-hidden="true" tabindex="-1"></a><span class="kw">CREATE</span> PROC q ()</span>
+<span id="cb193-3"><a href="#cb193-3" aria-hidden="true" tabindex="-1"></a><span class="cf">BEGIN</span></span>
+<span id="cb193-4"><a href="#cb193-4" aria-hidden="true" tabindex="-1"></a>  <span class="kw">DECLARE</span> C <span class="kw">CURSOR</span> <span class="kw">LIKE</span> <span class="kw">SELECT</span> <span class="ot">&quot;1&quot;</span> <span class="kw">AS</span> x, <span class="dv">2</span> <span class="kw">AS</span> y;</span>
+<span id="cb193-5"><a href="#cb193-5" aria-hidden="true" tabindex="-1"></a>  FETCH C <span class="kw">USING</span></span>
+<span id="cb193-6"><a href="#cb193-6" aria-hidden="true" tabindex="-1"></a>   <span class="ot">&quot;foo&quot;</span> x,</span>
+<span id="cb193-7"><a href="#cb193-7" aria-hidden="true" tabindex="-1"></a>   <span class="dv">3</span> y;</span>
+<span id="cb193-8"><a href="#cb193-8" aria-hidden="true" tabindex="-1"></a>  <span class="kw">OUT</span> C;</span>
+<span id="cb193-9"><a href="#cb193-9" aria-hidden="true" tabindex="-1"></a><span class="cf">END</span>;</span>
+<span id="cb193-10"><a href="#cb193-10" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb193-11"><a href="#cb193-11" aria-hidden="true" tabindex="-1"></a><span class="kw">CREATE</span> PROC p ()</span>
+<span id="cb193-12"><a href="#cb193-12" aria-hidden="true" tabindex="-1"></a><span class="cf">BEGIN</span></span>
+<span id="cb193-13"><a href="#cb193-13" aria-hidden="true" tabindex="-1"></a>  <span class="kw">DECLARE</span> C <span class="kw">CURSOR</span> FETCH <span class="kw">FROM</span> <span class="kw">CALL</span> q();</span>
+<span id="cb193-14"><a href="#cb193-14" aria-hidden="true" tabindex="-1"></a>  <span class="co">-- do something with C</span></span>
+<span id="cb193-15"><a href="#cb193-15" aria-hidden="true" tabindex="-1"></a><span class="cf">END</span>;</span></code></pre></div>
+<p>Let’s discuss some of what is above, first looking at <code>q</code>:</p>
+<ul>
+<li><code>DECLARE C CURSOR LIKE SELECT "1" AS x, 2 AS y;</code> : this makes an empty value cursor
+<ul>
+<li>note the shape is <code>LIKE</code> the indicated <code>SELECT</code>, the <code>SELECT</code> does not actually run</li>
+</ul></li>
+<li><code>FETCH ... USING</code> : this form is sugar, it lets you put the column names <code>x</code> and <code>y</code> adjacent to the values but is otherwise equivalent to the canonical form
+<ul>
+<li><code>FETCH C(x, y) FROM VALUES("foo", 3);</code> is the canonical form</li>
+<li>codegen only ever sees the canonical form</li>
+</ul></li>
+<li><code>OUT C</code> is new, we’ll cover this shortly</li>
+</ul>
+<p>Now let’s look at the C for <code>q</code></p>
+<div class="sourceCode" id="cb194"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb194-1"><a href="#cb194-1" aria-hidden="true" tabindex="-1"></a><span class="kw">typedef</span> <span class="kw">struct</span> q_row <span class="op">{</span></span>
+<span id="cb194-2"><a href="#cb194-2" aria-hidden="true" tabindex="-1"></a>  cql_bool _has_row_<span class="op">;</span></span>
+<span id="cb194-3"><a href="#cb194-3" aria-hidden="true" tabindex="-1"></a>  cql_uint16 _refs_count_<span class="op">;</span></span>
+<span id="cb194-4"><a href="#cb194-4" aria-hidden="true" tabindex="-1"></a>  cql_uint16 _refs_offset_<span class="op">;</span></span>
+<span id="cb194-5"><a href="#cb194-5" aria-hidden="true" tabindex="-1"></a>  cql_int32 y<span class="op">;</span></span>
+<span id="cb194-6"><a href="#cb194-6" aria-hidden="true" tabindex="-1"></a>  cql_string_ref _Nonnull x<span class="op">;</span></span>
+<span id="cb194-7"><a href="#cb194-7" aria-hidden="true" tabindex="-1"></a><span class="op">}</span> q_row<span class="op">;</span></span>
+<span id="cb194-8"><a href="#cb194-8" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb194-9"><a href="#cb194-9" aria-hidden="true" tabindex="-1"></a><span class="pp">#define q_refs_offset cql_offsetof(q_row, x) </span><span class="co">// count = 1</span></span>
+<span id="cb194-10"><a href="#cb194-10" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb194-11"><a href="#cb194-11" aria-hidden="true" tabindex="-1"></a>cql_string_literal<span class="op">(</span>_literal_1_foo_q<span class="op">,</span> <span class="st">&quot;foo&quot;</span><span class="op">);</span></span>
+<span id="cb194-12"><a href="#cb194-12" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb194-13"><a href="#cb194-13" aria-hidden="true" tabindex="-1"></a><span class="kw">typedef</span> <span class="kw">struct</span> q_C_row <span class="op">{</span></span>
+<span id="cb194-14"><a href="#cb194-14" aria-hidden="true" tabindex="-1"></a>  cql_bool _has_row_<span class="op">;</span></span>
+<span id="cb194-15"><a href="#cb194-15" aria-hidden="true" tabindex="-1"></a>  cql_uint16 _refs_count_<span class="op">;</span></span>
+<span id="cb194-16"><a href="#cb194-16" aria-hidden="true" tabindex="-1"></a>  cql_uint16 _refs_offset_<span class="op">;</span></span>
+<span id="cb194-17"><a href="#cb194-17" aria-hidden="true" tabindex="-1"></a>  cql_int32 y<span class="op">;</span></span>
+<span id="cb194-18"><a href="#cb194-18" aria-hidden="true" tabindex="-1"></a>  cql_string_ref _Nonnull x<span class="op">;</span></span>
+<span id="cb194-19"><a href="#cb194-19" aria-hidden="true" tabindex="-1"></a><span class="op">}</span> q_C_row<span class="op">;</span></span>
+<span id="cb194-20"><a href="#cb194-20" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb194-21"><a href="#cb194-21" aria-hidden="true" tabindex="-1"></a><span class="pp">#define q_C_refs_offset cql_offsetof(q_C_row, x) </span><span class="co">// count = 1</span></span>
+<span id="cb194-22"><a href="#cb194-22" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb194-23"><a href="#cb194-23" aria-hidden="true" tabindex="-1"></a><span class="dt">static</span> <span class="dt">void</span> q<span class="op">(</span>q_row <span class="op">*</span>_Nonnull _result_<span class="op">)</span> <span class="op">{</span></span>
+<span id="cb194-24"><a href="#cb194-24" aria-hidden="true" tabindex="-1"></a>  memset<span class="op">(</span>_result_<span class="op">,</span> <span class="dv">0</span><span class="op">,</span> <span class="kw">sizeof</span><span class="op">(*</span>_result_<span class="op">));</span></span>
+<span id="cb194-25"><a href="#cb194-25" aria-hidden="true" tabindex="-1"></a>  q_C_row C <span class="op">=</span> <span class="op">{</span> <span class="op">.</span>_refs_count_ <span class="op">=</span> <span class="dv">1</span><span class="op">,</span> <span class="op">.</span>_refs_offset_ <span class="op">=</span> q_C_refs_offset <span class="op">};</span></span>
+<span id="cb194-26"><a href="#cb194-26" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb194-27"><a href="#cb194-27" aria-hidden="true" tabindex="-1"></a>  C<span class="op">.</span>_has_row_ <span class="op">=</span> <span class="dv">1</span><span class="op">;</span></span>
+<span id="cb194-28"><a href="#cb194-28" aria-hidden="true" tabindex="-1"></a>  cql_set_string_ref<span class="op">(&amp;</span>C<span class="op">.</span>x<span class="op">,</span> _literal_1_foo_q<span class="op">);</span></span>
+<span id="cb194-29"><a href="#cb194-29" aria-hidden="true" tabindex="-1"></a>  C<span class="op">.</span>y <span class="op">=</span> <span class="dv">3</span><span class="op">;</span></span>
+<span id="cb194-30"><a href="#cb194-30" aria-hidden="true" tabindex="-1"></a>  _result_<span class="op">-&gt;</span>_has_row_ <span class="op">=</span> C<span class="op">.</span>_has_row_<span class="op">;</span></span>
+<span id="cb194-31"><a href="#cb194-31" aria-hidden="true" tabindex="-1"></a>  _result_<span class="op">-&gt;</span>_refs_count_ <span class="op">=</span> <span class="dv">1</span><span class="op">;</span></span>
+<span id="cb194-32"><a href="#cb194-32" aria-hidden="true" tabindex="-1"></a>  _result_<span class="op">-&gt;</span>_refs_offset_ <span class="op">=</span> q_refs_offset<span class="op">;</span></span>
+<span id="cb194-33"><a href="#cb194-33" aria-hidden="true" tabindex="-1"></a>  cql_set_string_ref<span class="op">(&amp;</span>_result_<span class="op">-&gt;</span>x<span class="op">,</span> C<span class="op">.</span>x<span class="op">);</span></span>
+<span id="cb194-34"><a href="#cb194-34" aria-hidden="true" tabindex="-1"></a>  _result_<span class="op">-&gt;</span>y <span class="op">=</span> C<span class="op">.</span>y<span class="op">;</span></span>
+<span id="cb194-35"><a href="#cb194-35" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb194-36"><a href="#cb194-36" aria-hidden="true" tabindex="-1"></a>  cql_teardown_row<span class="op">(</span>C<span class="op">);</span></span>
+<span id="cb194-37"><a href="#cb194-37" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span></code></pre></div>
+<ul>
+<li>the <code>_result_</code> variable is clobbed with zeros, it is assumed to be junk coming in
+<ul>
+<li>if it had valid data, the caller is expected to use <code>cql_teardown_row</code> to clean it up <em>before</em> calling</li>
+</ul></li>
+<li><code>q_row</code> : this is new, this is the structure type for the result of <code>q</code>
+<ul>
+<li>it’s exactly the same shape as C</li>
+<li>it has its own <code>q_refs_offset</code> like other shapes</li>
+</ul></li>
+<li><code>q_C_row</code> : this is the same old same old row structure for cursor C</li>
+<li><code>static void q(q_row *_Nonnull _result_)</code> : q now accepts a q_row to fill in!
+<ul>
+<li>note that <code>q</code> does not have the <code>_db_</code> parameter, it doesn’t use the database!</li>
+<li>it is entirely possible to fill value cursors from non-database sources, e.g. constants, math, whatever</li>
+</ul></li>
+<li><code>C</code> : the value cursor is declared as usual</li>
+<li><code>C.x</code> and <code>C.y</code> are loaded, this resolves the <code>FETCH</code> statement</li>
+<li>the <code>_result_</code> fields are copied from <code>C</code>, this resolves the <code>OUT</code> statement</li>
+<li><code>C</code> can be torn down</li>
+<li>there is no cleanup label, there are no error cases, nothing can go wrong!</li>
+</ul>
+<p>The net of all this is that we have loaded a value cursor that was passed in to the procedure via a hidden argument and it has retained references as appropriate.</p>
+<p>Now let’s look at <code>p</code>:</p>
+<div class="sourceCode" id="cb195"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb195-1"><a href="#cb195-1" aria-hidden="true" tabindex="-1"></a><span class="kw">typedef</span> <span class="kw">struct</span> p_C_row <span class="op">{</span></span>
+<span id="cb195-2"><a href="#cb195-2" aria-hidden="true" tabindex="-1"></a>  cql_bool _has_row_<span class="op">;</span></span>
+<span id="cb195-3"><a href="#cb195-3" aria-hidden="true" tabindex="-1"></a>  cql_uint16 _refs_count_<span class="op">;</span></span>
+<span id="cb195-4"><a href="#cb195-4" aria-hidden="true" tabindex="-1"></a>  cql_uint16 _refs_offset_<span class="op">;</span></span>
+<span id="cb195-5"><a href="#cb195-5" aria-hidden="true" tabindex="-1"></a>  cql_int32 y<span class="op">;</span></span>
+<span id="cb195-6"><a href="#cb195-6" aria-hidden="true" tabindex="-1"></a>  cql_string_ref _Nonnull x<span class="op">;</span></span>
+<span id="cb195-7"><a href="#cb195-7" aria-hidden="true" tabindex="-1"></a><span class="op">}</span> p_C_row<span class="op">;</span></span>
+<span id="cb195-8"><a href="#cb195-8" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb195-9"><a href="#cb195-9" aria-hidden="true" tabindex="-1"></a><span class="pp">#define p_C_refs_offset cql_offsetof(p_C_row, x) </span><span class="co">// count = 1</span></span>
+<span id="cb195-10"><a href="#cb195-10" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> p<span class="op">(</span><span class="dt">void</span><span class="op">)</span> <span class="op">{</span></span>
+<span id="cb195-11"><a href="#cb195-11" aria-hidden="true" tabindex="-1"></a>  p_C_row C <span class="op">=</span> <span class="op">{</span> <span class="op">.</span>_refs_count_ <span class="op">=</span> <span class="dv">1</span><span class="op">,</span> <span class="op">.</span>_refs_offset_ <span class="op">=</span> p_C_refs_offset <span class="op">};</span></span>
+<span id="cb195-12"><a href="#cb195-12" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb195-13"><a href="#cb195-13" aria-hidden="true" tabindex="-1"></a>  cql_teardown_row<span class="op">(</span>C<span class="op">);</span></span>
+<span id="cb195-14"><a href="#cb195-14" aria-hidden="true" tabindex="-1"></a>  q<span class="op">((</span>q_row <span class="op">*)&amp;</span>C<span class="op">);</span> <span class="co">// q_row identical to cursor type</span></span>
+<span id="cb195-15"><a href="#cb195-15" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb195-16"><a href="#cb195-16" aria-hidden="true" tabindex="-1"></a>  <span class="co">// usually you do something with C at this point</span></span>
+<span id="cb195-17"><a href="#cb195-17" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb195-18"><a href="#cb195-18" aria-hidden="true" tabindex="-1"></a>  cql_teardown_row<span class="op">(</span>C<span class="op">);</span></span>
+<span id="cb195-19"><a href="#cb195-19" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span></code></pre></div>
+<ul>
+<li><code>p_C_row</code> : the cursor type for <code>C</code> in the procedure <code>p</code> is defined</li>
+<li><code>p_C_refs_offset</code> : the refs offset for <code>C</code> in <code>p</code> as usual</li>
+<li><code>C = {...}</code> : the usual initialization for a cursor with shape
+<ul>
+<li>note that <code>C</code> is a value cursor, so it has no <code>C_stmt</code></li>
+</ul></li>
+<li><code>cql_teardown_row(C)</code> : releases any references in C, there are none
+<ul>
+<li>this pattern is general purpose, the call to <code>q</code> might be in a loop or something</li>
+<li>in this instance the teardown here is totally redundant, but harmless</li>
+</ul></li>
+<li><code>q((q_row *)&amp;C)</code> : fetch <code>C</code> by calling <code>q</code>
+<ul>
+<li><code>p_C_row</code> has been constructed to be exactly the same as <code>q_row</code> so this cast is safe</li>
+<li>there are no error checks because <code>q</code> can’t fail!</li>
+</ul></li>
+<li>some code that would use <code>C</code> is absent for this sample, it would go where the comment is</li>
+<li>the cleanup label is missing because there are no error cases, emitting the label would just cause warnings
+<ul>
+<li>warnings are often escalated to errors in production builds…</li>
+</ul></li>
+<li><code>cql_teardown_row(C)</code> is needed as always,
+<ul>
+<li>even though there is no cleanup label the <code>teardown</code> is in the cleanup section</li>
+<li>the <code>teardown</code> was added as usual when <code>C</code> was declared</li>
+</ul></li>
+</ul>
+<p>So with just normal value cursor codegen we can pretty easily create a situation where procedures can move structures from one to another. As we saw, the source of value cursors may or may not be the database. Value cursors are frequently invaluable in test code as they can easily hold mock rows based on any kind of computation.</p>
+<h3 id="next-result-sets-and-out-union">Next: Result Sets and OUT UNION</h3>
 </body>
 </html>

--- a/CQL_Guide/int02.md
+++ b/CQL_Guide/int02.md
@@ -247,7 +247,7 @@ typedef struct sem_node {
 
 * `sem_type` : already discussed above, this tells you how to interpret everything else
 * `name` : variables, columns, etc. have a canonical name, when a name case-insenstively resolves, the canonical name is stored here
-  * typically later passes emit the canonical variable name everywhere 
+  * typically later passes emit the canonical variable name everywhere
   * e.g. `FoO` and `fOO` might both resolve to an object declared as `foo`, we always emit `foo` in codegen
 * `kind` : in CQL any type can be discriminated as in `declare foo real<meters>`, the kind here is `meters`
   * two expressions of the same core type (e.g. `real`) are incompatible if they have a `kind` and the `kind` does not match
@@ -288,7 +288,7 @@ With these building blocks we can represent the type of anything in the CQL lang
 ### Initiating Semantic Analysis
 
 The semantic analysis pass runs much the same way as the AST emitter.  In `sem.c` there is the essential function `sem_main`. It suffices
-to call `sem_main` on the root of your AST. That root node is expect to be a `stmt_list` node.
+to call `sem_main` on the root of the AST. That root node is expected to be a `stmt_list` node.
 
 ```C
 // This method loads up the global symbol tables in either empty state or
@@ -305,7 +305,7 @@ cql_noexport void sem_main(ast_node *ast) {
 As you can see, `sem_main` begins by reseting all the global state.  You can of course do this yourself after calling `sem_main` (when you're done with the results).
 
 `sem_main` sets a variety of useful and public global variables that describe the results of the analysis.  The ones in `sem.h` are part of the contract and
-you should feel free to use them in a downstream code-generator.  Other items are internal and should be avoided. 
+you should feel free to use them in a downstream code-generator.  Other items are internal and should be avoided.
 The internal items are typically defined statically in `sem.c`. The essential outputs will be described in the last section of this part.
 
 The cleanup has this structure:
@@ -393,8 +393,8 @@ is only needed to make a good quality error message with validation being otherw
 ```
 
 Looking at the very first entry as an example, we see that `EXPR_INIT` creates a mapping between the AST type `num`
-and the analysis function `sem_expr_num` and that function will get the text `"NUM"` as an extra argument.  
-As it happens `sem_expr_num` doesn't need the extra argument, but `sem_binary_math` certainly needs the `"*"` 
+and the analysis function `sem_expr_num` and that function will get the text `"NUM"` as an extra argument.
+As it happens `sem_expr_num` doesn't need the extra argument, but `sem_binary_math` certainly needs the `"*"`
 as that function handles a large number of binary operators.
 
 Let's quickly go over this list as these are the most important analyzers:
@@ -437,7 +437,7 @@ is of type `SEM_TYPE_ERROR` using `is_error(ast)`.  If it is, the caller will ma
 the way up the tree.  The net of this is that wherever you begin semantic analysis, you can know if there were any problems by checking for an error at the
 top of the tree you provided.
 
-At the point of the initial error, the analyzer is expected to also call `report_error` providing a suitable message.  This will be logged to `stderr`.  
+At the point of the initial error, the analyzer is expected to also call `report_error` providing a suitable message.  This will be logged to `stderr`.
 In test mode it is also stored in the AST so that verification steps can confirm that errors were reported at exactly the right place.
 
 If there are no errors, then a suitable `sem_node` is created for the resulting type or else, at minimum, `record_ok(ast)` is used to place the shared "OK" type on the node.
@@ -863,8 +863,8 @@ cql_noexport bool_t is_numeric_compat(sem_t sem_type) {
 }
 ```
 
-`is_numeric_compat` operates by checking the core type for the numeric range.  
-Note that `NULL` is compatible with numerics because expressions like `NULL + 2` 
+`is_numeric_compat` operates by checking the core type for the numeric range.
+Note that `NULL` is compatible with numerics because expressions like `NULL + 2`
 have meaning in SQL.  The type of that expression is nullable integer and
 the result is `NULL`.
 
@@ -999,10 +999,10 @@ static void sem_while_stmt(ast_node *ast) {
 * `sem_numeric_expr` : verifies the loop expression is numeric
 * `sem_stmt_list` : recursively validates the body of the loop
 
-Note: the while expression is one of the loop constructs which means `LEAVE` and `CONTINUE` are legal inside it. 
+Note: the while expression is one of the loop constructs which means `LEAVE` and `CONTINUE` are legal inside it.
 The `loop_depth` global tracks the fact that we are in a loop so that analysis for `LEAVE` and `CONTINUE` can report errors if we are not.
 
-It's not hard to imagine that `sem_stmt_list` will basically walk the AST, pulling out statements and dispatching them using the `STMT_INIT` tables previously discussed.  
+It's not hard to imagine that `sem_stmt_list` will basically walk the AST, pulling out statements and dispatching them using the `STMT_INIT` tables previously discussed.
 You might land right back in `sem_while_stmt` for a nested `WHILE` -- it's turtles all the way down.
 
 If `SEM_EXPR_CONTEXT_NONE` is a mystery, don't worry it's covered in the next section.
@@ -1032,7 +1032,7 @@ The expression contexts are as follows:
 The idea here is simple, when calling a root expression, the analyzer provides the context value that has the bit that correponds to the current context.
 For instance, the expression being validated in is the `WHERE` clause, the code will provide `SEM_EXPR_CONTEXT_WHERE`.
 The inner validators check this context, in particular anything that is only available in some contexts has a bit-mask of that is the union
-of the context bits where it can be used.  The validator can check those possibilities against the current context with one bitwise "and" operation. 
+of the context bits where it can be used.  The validator can check those possibilities against the current context with one bitwise "and" operation.
 A zero result indicates that the operation is not valid in the current context.
 
 This bitwise "and" is performed by one of these two helper macros which makes the usage a little clearer:
@@ -1135,12 +1135,12 @@ static ast_node *find_usable_index(CSTR name, ast_node *err_target, CSTR msg) {
 }
 ```
 
-We haven't discussed schema regions yet but what you need to know about them for now is this:  
-* any object can be in a region. 
+We haven't discussed schema regions yet but what you need to know about them for now is this:
+* any object can be in a region.
 * a region may depend on other regions
 
-If an object is in a region, then it may only use schema parts that are in 
-the same region, or the region's dependencies (transitively).  
+If an object is in a region, then it may only use schema parts that are in
+the same region, or the region's dependencies (transitively).
 
 The point of this is that you might have a rather large schema and you probably don't want any peice
 of code to use any piece of schema.  You can use regions to ensure that the code for feature "X" doesn't
@@ -1160,7 +1160,7 @@ In short, these simple cases just require looking up the entity and verifying th
 #### Flexible Name Resolution
 
 The "hard case" for name resolution is where the name is occuring in an expression.  Such a name can refer to
-all manner of things. It could be a global variable, a local variable, an argument, a table column, a field in a cursor, 
+all manner of things. It could be a global variable, a local variable, an argument, a table column, a field in a cursor,
 and others.  The general name resolver goes through several phases looking for the name.  Each phase can either report
 an affirmative success or error (in which case the search stops), or it may simply report that the name was not found
 but the search should continue.
@@ -1463,7 +1463,7 @@ Briefly `sem_find_likeable_ast` does these steps:
 * if the right is the name of a procedure with a structure result, use that shape
 * if it's none of these, produce an error
 
-This is the primary source of shape reuse.  Let's look at how we might use that.  
+This is the primary source of shape reuse.  Let's look at how we might use that.
 
 Suppose we want to write a procedure that inserts a row into the table `Foo`, we could certainly list the columns of `Foo` as arguments like this:
 
@@ -1681,7 +1681,7 @@ We see these basic steps:
 Now we're all set up.
 
 * We can use `current_region` to set the `region` in the `sem_node` of anything we encounter
-* We can use `current_region_image` to quickly see if we are allowed to use any given region 
+* We can use `current_region_image` to quickly see if we are allowed to use any given region
   * if it's in the symbol table we can use it
 
 Recall that at the end of `sem_create_table_stmt` we do this:

--- a/CQL_Guide/int03.md
+++ b/CQL_Guide/int03.md
@@ -14,7 +14,7 @@ sidebar_label: "Part 3: C Code Generation"
 Part 3 continues with a discussion of the essentials of the C code generation pass of the CQL compiler.
 As in the previous sections, the goal here is not to go over every detail of code generation but rather to give
 a sense of how codegen happens in general -- the core strategies and implementation choices --
-so that when reading the code you have an idea how smaller pieces would fit into the whole. To accomplish
+so that when reading the code you will have an idea how smaller pieces would fit into the whole. To accomplish
 this, various key data structures will be explained in detail as well as selected examples of their use.
 
 ## C Code Generation
@@ -35,19 +35,19 @@ functions.  This all happens in `cg_c.c`.  From a big picture perspective, these
 * we have to track any reference types carefully so that retain/release pairs are done consistently
   * even in the presence of SQLite errors or other exceptions
 * we have to produce a `.h` and a `.c` file for the C compiler
-  * contributions to these files could come from various places
+  * contributions to these files could come from various places, not necessarily in order
   * the `.c` file will itself have various sections and we might need to contribute to them at various points in the compilation
 * we want to do this all in one pass over the AST
-* we get to assume that the program is error free, codegen never runs unless semantic analysis reports zero errors
+* we get to assume that the program is error-free -- codegen never runs unless semantic analysis reports zero errors
   * so nothing can be wrong by the time the codegen pass runs, we never detect errors here
-  * sometimes we add `Contract` and `Invariant` statements to `cg.c` that make our assumptions clear and prevent regressions
+  * sometimes we add `Contract` and `Invariant` statements to `cg.c` to make our assumptions clear and to prevent regressions
 
-There are some very important building blocks used to solve these problems we will start with those, then move to
+There are some very important building blocks used to solve these problems: we will start with those, then move to
 a discussion of each of the essential kinds of code generation that we have to do to get working programs.
 
 ### Launching the Code Generator
 
-Once semantic analysis is done all of the code generators have the same contract: they
+Once semantic analysis is done, all of the code generators have the same contract: they
 have a main function like `cg_c_main` for the C code generator.  It gets the root of
 the AST and it can use the public interface of the semantic analyzer to get additional
 information.  See [Part 2](https://cgsql.dev/cql-guide/int02) for those details.
@@ -97,9 +97,9 @@ DML (Data Manipulation Language) statements are declared similarly:
   STD_DML_STMT_INIT(delete_stmt);
 ```
 
-They are handled by `cg_std_dml_exec_stmt`; the processing is identical to
+The DML statements are handled by `cg_std_dml_exec_stmt`; the processing is identical to
 DDL except `CG_MINIFY_ALIASES` is specified.  This allows the code generator
-to remove unused column aliases in select statements to save space.
+to remove unused column aliases in `SELECT` statements to save space.
 
 ```
 // Straight up DML invocation.  The ast has the statement, execute it!
@@ -108,21 +108,21 @@ static void cg_std_dml_exec_stmt(ast_node *ast) {
 }
 ```
 
-Note that this flag difference only matters for the `create view` statement
+Note that this flag difference only matters for the `CREATE VIEW` statement
 but for symmetry all the DDL is handled with one macro and all the DML
 with the second macro.
 
 Next, the easiest case... there are a bunch of statements that create
-no code-gen at all.  These are type defintions that are interesting
-only to the semantic analyzer or other control statements.  Some examples:
+no code-gen at all.  These statements are type definitions that are interesting
+only to the semantic analyzer, or other control statements.  Some examples:
 
 ```C
   NO_OP_STMT_INIT(declare_enum_stmt);
   NO_OP_STMT_INIT(declare_named_type);
 ```
 
-Next, the general purpose statement handler.  This creates a mapping
-from the `if_stmt` AST node to `cg_if_stmt`.
+Next, the general purpose statement handler.  `STMT_INIT` creates mappings
+such as the `if_stmt` AST node mapping to `cg_if_stmt`.
 
 ```C
   STMT_INIT(if_stmt);
@@ -131,8 +131,8 @@ from the `if_stmt` AST node to `cg_if_stmt`.
   STMT_INIT(assign);
 ```
 
-The next group is the expressions, with precedence and operator specified. There is a lot of code sharing
-as you can see from this sample:
+The next group of declarations arethe expressions, with precedence and operator specified.
+There is a lot of code sharing between AST types as you can see from this sample:
 
 ```C
   EXPR_INIT(num, cg_expr_num, "num", C_EXPR_PRI_ROOT);
@@ -153,13 +153,14 @@ as you can see from this sample:
 Most (not all) of the binary operators are handled with one function `cg_binary` and likewise
 most unary operators are handled with `cg_unary`.
 
-Note: the precedence constants are the `C_EXPR_PRI_*` flavor because parentheses will be
-generated based on the C rules at this point.  Importantly, the AST still, and always
-has the user-specified order of operations encoded in it, there's no change there.  The
-only thing that changes is where parentheses are needed to get the desired result.  Parens
-may need to be added and some that were present in the original text might no longer be needed.
+Note: the precedence constants are the `C_EXPR_PRI_*` flavor because, naturally, parentheses
+will be generated based on the C rules during C codegen.  Importantly, the AST still, and always,
+authoritatively encodes the user-specified order of operations -- there's no change there.  The
+only thing that changes is where parentheses are needed to get the desired result.  Some parens
+may need to be added, and some that were present in the original text might no longer be needed.
 
-e.g.
+Here are some helpful examples:
+
 ```SQL
 CREATE PROC p ()
 BEGIN
@@ -179,7 +180,7 @@ void p(void) {
 }
 ```
 
-Finally, many built-in functions need special codegen.
+Finally, many built-in functions need special codegen, such as:
 
 ```C
   FUNC_INIT(coalesce);
@@ -190,13 +191,14 @@ Finally, many built-in functions need special codegen.
 
 ### Character Buffers and Byte Buffers
 
-The first kind of text output that CQL could produce was the AST echoing.  This was original done directly with `fprintf` but
-that was not flexible enough as the output had to be captured to be emitted into other places like comments or the text of
-SQL statements to go to SQLite.  This forces that pass to use character buffers, which we touched on in Part 1.  Code generation
-has a more profound dependency on character buffers -- they are literally all over `cg_c.c` and we need to go over how hey are used.
+The first kind of text output that CQL could produce was the AST echoing.  This was originally done directly with `fprintf` but
+that was never going to be flexible enough -- we have to be able to emitt that output into other places like comments, or the text of
+SQL statements.  This need forces that pass to use character buffers, which we touched on in Part 1.  C Code generation
+has a more profound dependency on character buffers -- they are literally all over `cg_c.c` and we need to go over how they are used
+if we're going to understand the codegen passes.
 
-The public interace is in `charbuf.h` and it's really quite simple.  You allocate a `charbuf` and then you can `bprintf` into it.
-Let's be a bit more specific:
+The public  interface for `charbuf` is in `charbuf.h` and it's really quite simple.  You allocate a `charbuf` and then you can
+`bprintf` into it. Let's be a bit more specific:
 
 ```C
 #define CHARBUF_INTERNAL_SIZE 1024
@@ -231,13 +233,13 @@ The typical pattern goes something like this:
 
 Note that `charbuf` includes `CHARBUF_INTERNAL_SIZE` of storage that does not
 have to be allocated with `malloc` and it doesn't grow very aggressively.
-This reflects that fact that most `charbuf` instances are very small.
+This economy reflects that fact that most `charbuf` instances are very small.
 Of course a `charbuf` could go on the heap if it needs to outlive
 the function it appears in, but this is exceedingly rare.
 
-To make sure buffers are consistently closed (and this is a problem because
-there are often a lot of them.  They are allocated with these simple helper
-macros.
+To make sure buffers are consistently closed -- and this is a problem because
+there are often a lot of them -- they are allocated with these simple helper
+macros:
 
 ```C
 #define CHARBUF_OPEN(x) \
@@ -250,7 +252,7 @@ macros.
   Invariant(__saved_charbuf_count##x == charbuf_open_count)
 ```
 
-the earlier example would be written more properly:
+The earlier example would be written more properly:
 
 ```C
   CHARBUF_OPEN(foo);
@@ -262,8 +264,8 @@ the earlier example would be written more properly:
 If you forget to close a buffer the count will get messed up and the next close will trigger an assertion failure.
 
 It's normal to create several buffers in the course of doing code generation.  In fact some of these buffers
-become "globally" visible and get swapped out as needed.  For instance this kind of chaining is normal.
-Inside of `cg_create_proc_stmt` there is these sequence:
+become "globally" visible and get swapped out as needed.  For instance, the kind of chaining we see
+inside of `cg_create_proc_stmt` is normal, here is the sequence:
 
 Make new buffers...
 ```C
@@ -273,7 +275,7 @@ Make new buffers...
   CHARBUF_OPEN(proc_cleanup);
 ```
 
-Save what we got...
+Save the current buffer pointers...
 ```C
   charbuf *saved_main = cg_main_output;
   charbuf *saved_decls = cg_declarations_output;
@@ -282,7 +284,7 @@ Save what we got...
   charbuf *saved_fwd_ref = cg_fwd_ref_output;
 ```
 
-Switch to the new...
+Switch to the new buffers...
 ```C
   cg_fwd_ref_output = &proc_fwd_ref;
   cg_main_output = &proc_body;
@@ -291,56 +293,60 @@ Switch to the new...
   cg_cleanup_output = &proc_cleanup;
 ```
 
-And of course the code puts the original values back when it's done and closes the buffers.
+And of course the code puts the original values back when it's done and then closes what it opened.
 
 This means that while processing a procedure the codegen that declares say scratch variables,
-which would go to `cg_scratch_vars_output` is going to target the `proc_locals` buffer
-which will be emitted before the `body`.  By the time `cg_stmt_list` is invoked the
+which would go to `cg_scratch_vars_output`, is going to target the `proc_locals` buffer
+which will be emitted before the `proc_body`.  By the time `cg_stmt_list` is invoked the
 `cg_main_output` variable will be pointing to the procedure body, thus any statements
-will go into there rather than being acculated at the global level -- it's possible to
-have code that is not in a procedure (see [`--global_proc`](https://cgsql.dev/cql-guide/x1#--global_proc-name)).
+will go into there rather than being acculated at the global level.
 
-But in general, it's very useful to have different buffers going on at the same time.  New local variables
-or scratch variables can be added to their own buffer which goes before the code runs.  New cleanup
-steps that are necessary can be added to the cleanup output which will appear at the end.  The final
-function combines all of these pieces with maybe some glue.  Everything works like this, `IF` statements,
-expressions, all of it.
+Note: it's possible to have code that is not in a procedure (see [`--global_proc`](https://cgsql.dev/cql-guide/x1#--global_proc-name)).
+
+In general, it's very useful to have different buffers open at the same time.  New local variables
+or scratch variables can be added to their own buffer. New cleanup steps that are necessary can be added to
+`cg_cleanup_output` which will appear at the end of a procedure. The final steps of procedure codegen
+combines all of these pieces plus a little glue to make a working procedure.
+
+All codegen works like this -- statements, expressions, all of it.
 
 One interesting but unexpected feature of `charbuf` is that it provides helper methods for indenting
-buffer by whatever amount you like.  This turns out to be invaluable in creating well formatted C
-code because of course you want (e.g.) the body of an `if` statement to be indented.  CQL tries to create
+a buffer by whatever amount you like.  This turns out to be invaluable in creating well formatted C
+code because of course we want (e.g.) the body of an `if` statement to be indented.  CQL tries to create
 well formatted code that is readable by humans as much as possible.
 
 #### Byte Buffers
 
-These are less commonly used but there is a peer to `charbuf` creatively called `bytebuf`.  This gives you
-a growable binary buffer.  It's often used to hold arrays of structures.  Interestingly, `cg_c.c` doesn't
-currently consume byte buffers, the presence of `bytebuf.c` actually came late to the CQL compiler. However
-the CQL runtime `cqlrt.c` (and `cqlrt_common.c`) provide `cql_bytebuf_open`, `cql_bytebuf_alloc` and,
-`cql_bytebuf_close` which are akin to the `charbuf` methods.  These functions are used in the generated
-code to create result sets at runtime.  The `bytebuf` was so useful that it found its way back from the
-runtime into the compiler itself, and is used by other code-generators like the schema upgrader.   The
-semantic analyzer also uses it to help with query fragments and to track the various upgrade annotations.
+The byte buffers type, creatively called `bytebuf` is less commonly used.  It is a peer to `charbuf`
+and provides a growable binary buffer.  `bytebuf` is often used to hold arrays of structures.
+Interestingly, `cg_c.c` doesn't currently consume byte buffers, the presence of `bytebuf.c` actually
+came late to the CQL compiler. However the CQL runtime `cqlrt.c` (and `cqlrt_common.c`) provide
+`cql_bytebuf_open`, `cql_bytebuf_alloc` and, `cql_bytebuf_close` which are akin to the `charbuf` methods.
+These functions *are* used in the generated code to create result sets at runtime.
 
-Both `charbuf` and `bytebuf` are simple enough that they don't need discussion. It's easier to just read
-the code and the comments.
+`bytebuf` was so useful that it found its way back from the runtime into the compiler itself, and is used by
+other code-generators like the schema upgrader.   The semantic analyzer also uses it to help with query
+fragments and to track the various upgrade annotations.
+
+Both `charbuf` and `bytebuf` are simple enough that they don't need special discussion. Surveying
+their code and comments is an excellent exercise for the reader.
 
 ### Expressions
 
-Many of the output needs of CQL stemmed from the base case of creating expressions.  A simple CQL
-expression like
+Many of the output needs of CQL stemmed from the base case of creating the code for CQL expressions.
+A simple CQL expression like:
 
 ```sql
   SET x := x + y;
 ````
 
-seems innocuous enough, we'd like this to compile to this code:
+seems innocuous enough, and we'd like that expression to compile to this code:
 
 ```C
   x = x + y;
 ```
 
-And indeed, it might.  Here's some actual output from the compiler:
+And indeed, it does.  Here's some actual output from the compiler:
 
 ```C
 /*
@@ -362,10 +368,10 @@ void p(void) {
 #undef _PROC_
 ```
 
-(*) the output above was created by using `out/cql --in x --cg x.h x.c --nolines` to avoid all the # directives
+(*) the output above was created by using `out/cql --in x --cg x.h x.c --nolines` to avoid all the `#` directives
 
-Looks easy enough.  And indeed if all expressions were like this, you could do expression compilation pretty simply --
-every binary operator would look something like this:
+That expression looks easy enough. And indeed if all expressions were like this, we could do expression compilation
+pretty simply -- every binary operator would look something like this:
 
 * recurse left
 * emit infix operator
@@ -374,8 +380,9 @@ every binary operator would look something like this:
 This would sort of build up your expressions inside out and your final buffer after all the recursion was done would have
 the whole expression.
 
-This doesn't work at all.  To illustrate what goes wrong, we only have to change the test case a tiny bit.  The result
-is telling:
+This doesn't work at all.
+
+To illustrate what goes wrong, we only have to change the test case a tiny bit.  The result is telling:
 
 ```C
 /*
@@ -399,12 +406,22 @@ void p(void) {
 #undef _PROC_
 ```
 
-All that's happened in the above is that `x` and `y` became nullable variables, that is the `NOT NULL` was
-removed from the declaration.  This makes all the difference in the world, and this is a fairly easy case.
-The problem is that nullable value types like cql_nullable_int32 have an integer and a boolean and these
-don't flow into expressions that use operators like `+`, `-`, `/` and so forth.  This means that even
-simple expressions involving nullable types actually expand into several statements.  And, in general,
-these statements need a place to put their temporary results to accumulate the answer, so scratch variables
+In this new example above, `x` and `y` became nullable variables i.e. the `NOT NULL` was
+removed from their declarations -- this makes all the difference in the world.
+
+Let's take a quick look at `cql_nullable_int32` and we'll see the crux of the problem immediately:
+
+```C
+typedef struct cql_nullable_int32 {
+ cql_bool is_null;
+ cql_int32 value;
+} cql_nullable_int32;
+```
+
+The problem is that nullable value types like `cql_nullable_int32` have both their `value` field
+and a boolean `is_null` and these don't flow into expressions that use operators like `+`, `-`, `/` and so forth.
+This means that even simple expressions involving nullable types actually expand into several statements.  And, in general,
+these statements need a place to put their temporary results to accumulate the correct answer, so scratch variables
 are required to make all this work.
 
 Here's a more realistic example:
@@ -436,9 +453,9 @@ void combine(cql_nullable_int32 x, cql_nullable_int32 y, cql_nullable_int32 *_No
 #pragma clang diagnostic pop
 ```
 
-* `_tmp_n_int_1` holds the product of x and 5, it's null if `x.is_null` is true
-* `_tmp_n_int_2` holds the product of y and 3, it's null if `y.is_null` is true
-* `*result` holds the answer, it's null if either of `_tmp_n_int_1.is_null`, `_tmp_n_int_2.is_null` is true
+* `_tmp_n_int_1` : holds the product of x and 5, it's null if `x.is_null` is true
+* `_tmp_n_int_2` : holds the product of y and 3, it's null if `y.is_null` is true
+* `*result` : holds the answer, it's null if either of `_tmp_n_int_1.is_null`, `_tmp_n_int_2.is_null` is true
    * otherwise it's `_tmp_n_int_1.value + _tmp_n_int_2.value`
 
 So, in general, we need to emit arbitarily many statements in the course of evaluating even simple looking expressions
@@ -459,82 +476,93 @@ The function that actually assigns scratch variables is `cg_scratch_var`
 static void cg_scratch_var(ast_node *ast, sem_t sem_type, charbuf *var, charbuf *is_null, charbuf *value)
 ```
 
-The signature is a bit unexpected so we'll go over this, some of this will make more
-sense as we learn about expressions generally but this is as good an introduction as any.
+The signature is a bit unexpected so we'll go over it, some of below will make more
+sense as we learn about expressions generally, but this is as good an introduction as any.
 
-* `ast` holds a reference to a variable we want to assign to, this is normally `NULL` for scratch variables, it's not null for the `RESULT` macros which we'll study later, so for now ignore this
-* `sem_type` holds the type of the variable we need, it must be a unitary type, optionally with `SEM_TYPE_NOTNULL` set
-* `var` is a character buffer that will get the name of the variable
-* `is_null` is a character buffer that will get the `is_null` expression for this variable (more below)
-* `value` is a character buffer that will get the `value` expression for this variable (more below)
+* `ast` : holds a reference to a variable we want to assign to
+  * this argument is normally `NULL` for scratch variables
+  * `ast` is not null for the `RESULT` macros which we'll study later
+  * for now, we can basically ignore this argument
+* `sem_type` : holds the type of the variable we need
+  * it must be a unitary type, optionally with `SEM_TYPE_NOTNULL` set
+* `var` : a character buffer that will get the name of the variable
+* `is_null` : a character buffer that will get the `is_null` expression for this variable (more below)
+* `value` : a character buffer that will get the `value` expression for this variable (more below)
 
 And this is a good time to talk about `is_null` and `value` because they will be everywhere.
 
-Every expression evaluation in the C code generator has two essential results, the text that corresponds to the current
-value so far (e.g. "(1+2)*3") and the text for the current expression that will tell you if the result is null,
-this could be as simple as "0" for a expression that is known to be not null.  So let's make this a little more concrete:
+The codegen for expressions in the C code generator produces two results:
+* the text that corresponds to the current value so far (e.g. "(1+2)*3"), and,
+* the text that will tell you if the current value is null
+  * this could be as simple as "0" for an expression that is known to be not null
 
-Suppose you ask for a scratch not null integer we get results like this:
+Let's make this a little more concrete:
+
+Suppose we ask for a scratch "not null integer", we get results like this:
 
 * `var`:  `"_tmp_n_int_1"`
 * `is_null`: `"0"`
 * `value`: `"_tmp_n_int_1"`
 
-Meaning: if you want the value, use the text "_tmp_n_int_1" if you want to know if the variable is null, use the text "0"
+Meaning: if we want the value, use the text `"_tmp_n_int_1"` if we want to know if the variable is null, we use the text `"0"`
+
 Note: many parts of `cg_c.c` special case an `is_null` value of `"0"` to make better code because such a thing is known to
 be not null at compile time.
 
-Now let's suppose you ask for a scratch nullable integer, we get results like this:
+Now let's suppose we ask for a scratch nullable integer, we get results like this:
 
 * `var`:  `"_tmp_int_1"`
 * `is_null`: `"_tmp_int_1.is_null"`
 * `value`: `"_tmp_int_1.value"`
 
-So again, you have exactly the text you need to test for null and the test you need to get the value.
+So again, we have exactly the text we need to test for null, and the test we need to get the value.
 
 Additional notes:
 
 * scratch variables can be re-used, they are on a "stack"
 * a bitmask is used to track which scratch variables have aleady had a declaration emitted, so they are only declared once
 * the variable name is based on the current value of the `stack_level` variable which is increased in a push/pop fashion as temporaries come in and out of scope
-* this strategy isn't perfect, but the C compiler can consolidate locals even if the CQL codegen is not perfect so it ends up being not so bad
-* importantly there is one stacklevel variable for all temporaries not one stacklevel for every type of temporary, this seemed like a reasonable simplification
+  * this strategy isn't perfect, but the C compiler can consolidate locals even if the CQL codegen is not perfect so it ends up being not so bad
+  * importantly, there is one `stack_level` variable for all temporaries not one `stack_level` for every type of temporary, this seemed like a reasonable simplification
 
 
 #### Allocating Scratch Variables
 
-The most common reason for a scratch variable is that a temporary is needed for some part of the computation.
-The most common reason for a temporary variable is to hold an intermediate result of a computation involving
-nullable arithmetic.
+The most common reason to create a "scratch" variable is that a temporary variable is needed for some part of the computation.
+The most common reason for a temporary variable is to hold an intermediate result of a computation involving nullable arithmetic.
 
-These temporaries are created with `CG_PUSH_TEMP` which simply creates the three `charbuf` variables you need and then asks for a
-scratch variable of the type you need.  The variables follow a simple naming convention.  The stack level is increased.
+These temporaries are created with `CG_PUSH_TEMP` which simply creates the three `charbuf` variables needed and then asks for a
+scratch variable of the required type.  The variables follow a simple naming convention.  The stack level is increased after
+each temporary is allocated.
 
 ```C
 // Create buffers for a temporary variable.  Use cg_scratch_var to fill in the buffers
 // with the text needed to refer to the variable.  cg_scratch_var picks the name
 // based on stack level-and type.
 #define CG_PUSH_TEMP(name, sem_type) \
-CHARBUF_OPEN(name); \
-CHARBUF_OPEN(name##_is_null); \
-CHARBUF_OPEN(name##_value); \
-cg_scratch_var(NULL, sem_type, &name, &name##_is_null, &name##_value); \
-stack_level++;
+  CHARBUF_OPEN(name); \
+  CHARBUF_OPEN(name##_is_null); \
+  CHARBUF_OPEN(name##_value); \
+  cg_scratch_var(NULL, sem_type, &name, &name##_is_null, &name##_value); \
+  stack_level++;
 ```
 
-Symetrically, `CG_POP_TEMP` releases the charbufs and restores the stack level.  As with the other macros, these are designed to
-make it impossible to forget to free your buffers or get the stack wrong.  In fact, the stack is checked at strategic places
-to ensure its back to baseline.  You can always just snapshot `stacklevel`, do some work that should be clean, and then
-add an `Invariant` that `stacklevel` is back to where it was.
+Symmetrically, `CG_POP_TEMP` closes the `charbuf` variables and restores the stack level.
 
 ```C
 // Release the buffers for the temporary, restore the stack level.
 #define CG_POP_TEMP(name) \
-CHARBUF_CLOSE(name##_value); \
-CHARBUF_CLOSE(name##_is_null); \
-CHARBUF_CLOSE(name); \
-stack_level--;
+  CHARBUF_CLOSE(name##_value); \
+  CHARBUF_CLOSE(name##_is_null); \
+  CHARBUF_CLOSE(name); \
+  stack_level--;
 ```
+
+As with the other `PUSH/POP` `OPEN/CLOSE` macro types, these macros are designed to make it impossible
+to forget to free the buffers, or to get the stack level wrong.  The stack level can be (and is) checked
+at strategic places to ensure it's back to baseline -- this is easy because the code can always just
+snapshot `stack_level`, do some work that should be clean, and then check that `stack_level` is back to
+ where it's supposed to be with an `Invariant`.
 
 #### Recursing Sub-expressions
 
@@ -544,7 +572,14 @@ and how the evaluation works within that pattern.  This is everywhere in `cg_c.c
 So let's look at an actual evaluator, the simplest of them all, this one does code generation for the `NULL` literal.
 
 ```C
-static void cg_expr_null(ast_node *expr, CSTR op, charbuf *is_null, charbuf *value, int32_t pri, int32_t pri_new) {
+static void cg_expr_null(
+  ast_node *expr,
+  CSTR op,
+  charbuf *is_null,
+  charbuf *value,
+  int32_t pri,
+  int32_t pri_new)
+{
   Contract(is_ast_null(expr));
   // null literal
   bprintf(value, "NULL");
@@ -554,7 +589,7 @@ static void cg_expr_null(ast_node *expr, CSTR op, charbuf *is_null, charbuf *val
 
 Now this may be looking familiar: the signature of the code generator is something very much like the
 signature of the the `gen_` functions in the echoing code.  That's really because in some sense
-the echoing code is like a very simple code generator itself.
+the echoing code is a very simple code generator itself.
 
 * `expr` : the AST we are generating code for
 * `op` : the relevant operator if any (operators share code)
@@ -566,14 +601,17 @@ the echoing code is like a very simple code generator itself.
 This particular generator is going to produce `"NULL"` for the `value` and `"1"` for the `is_null` expression.
 
 `is_null` and `value` are the chief outputs, and the caller will use these to create its own expression results
-with recursive logic.  But the expression logic can also write into the statement stream, and as we'll see,
-it does.
+with recursive logic.  But the expression logic can also write into the statement stream, the cleanup stream,
+even into the header file stream, and as we'll see, it does.
 
 `pri` and `pri_new` work exactly like they did in the echoing code (see [Part 1](https://cgsql.dev/cql-guide/int01)),
 they are used to allow the code generator to decide if it needs to emit parentheses.  But recall that the binding strengths
 now will be the C binding strengths NOT the SQL binding strengths (discussed above).
 
 Let's look at one of the simplest operators: the `IS NULL` operator handled by `cg_expr_is_null`
+
+Note: this code has a simpler signature because it's actually part of codegen for `cg_expr_is` which
+has the general contract.
 
 ```C
 // The code-gen for is_null is one of the easiest.  The recursive call
@@ -601,14 +639,14 @@ static void cg_expr_is_null(ast_node *expr, charbuf *is_null, charbuf *value) {
 }
 ```
 
-So walking through this:
+So walking through the above:
 * the result of `IS NULL` is never null, so we can immediately put "0" into the `is_null` buffer
 * if the operand is a not-null numeric type then the result of `IS NULL` is `0`
 * if the operand might actually be null then
   * use `CG_PUSH_EVAL` to recursively do codegen for it
   * copy its `expr_is_null` text into our `value` text
 
-Note: the code reveals one of the big CQL secrets that not null reference variables can be null...  C has the same issue with `_Nonnull` globals.
+Note: the code reveals one of the big CQL secrets -- that not null reference variables can be null...  C has the same issue with `_Nonnull` globals.
 
 Now let's look at those helper macros, they are pretty simple:
 
@@ -617,23 +655,26 @@ Now let's look at those helper macros, they are pretty simple:
 // burn the stack slot so that any type and numbered temporary that was needed
 // won't be re-used until this scope is over.
 #define CG_PUSH_EVAL(expr, pri) \
-CHARBUF_OPEN(expr##_is_null); \
-CHARBUF_OPEN(expr##_value); \
-cg_expr(expr, &expr##_is_null, &expr##_value, pri); \
-stack_level++;
-````
+  CHARBUF_OPEN(expr##_is_null); \
+  CHARBUF_OPEN(expr##_value); \
+  cg_expr(expr, &expr##_is_null, &expr##_value, pri); \
+  stack_level++;
+```
 
 The push macro simply creates buffers to hold the `is_null` and `value` results, then it calls `cg_expr` to dispatch the indicated expression.
-The `pri` value provided to this macro represents the binding strength that the callee should assume its parent has.  Usually this is your `pri_new`
-value but often you can use `C_EXPR_PRI_ROOT` if you know that, because of your current context, the callee will never need parentheses.
+The `pri` value provided to this macro represents the binding strength that the callee should assume its parent has.  Usually this is the `pri_new` of the caller.
+but often `C_EXPR_PRI_ROOT` can be used if the current context implies that the callee will never need parentheses.
 
-How do we know this here? It seems like the operand of `IS NULL` could be anything surely it might need parentheses?  Let's consider:
+How do we know that parens are not needed here? It seems like the operand of `IS NULL` could be anything, surely it might need parentheses?  Let's consider:
 
 * if the operand is of not null numeric type then we aren't even going to evaluate it, we're on the easy "no it's not null" path
+  * no parens there
 * if the operand is nullable then the only place the answer can be stored is in a scratch variable and its `is_null` expression will be exactly like `var.is_null`
+  * no parens there
 * if the operand is a reference type, there are no operators that combine reference types to get more reference types, so again the result must be in a variable, and is `is_null` expression will be like `!var`
+  * no parens there
 
-None of these require further wrapping regardless of what is above this node in the tree because of he strength of the `.` and `!` operators.
+So, none of these require further wrapping regardless of what is above the `IS NULL` node in the tree because of the high strength of the `.` and `!` operators.
 
 Other cases are usually simpler, such as "no parentheses need to be added by the child node becasue it will be used as the argument to a helper
 function so there will always be parens hard-coded anyway".  However these things need to be carefully tested hence the huge variety of codegen tests.
@@ -650,13 +691,13 @@ CHARBUF_CLOSE(expr##_is_null); \
 stack_level--;
 ```
 
-`CG_POP_EVAL` simply closes the buffers and restores the stack.
+`CG_POP_EVAL` simply closes the buffers and restores the stack level.
 
 #### Result Variables
 
-When recursion happens in the codegen, the common place that the result will be found is
-in a temporary variable -- the generated code will use one or more statements to arrange for the correct
-answer to be in that variable.  To do this, the codegen needs to first get the name of a suitable
+When recursion happens in the codegen, a common place that the result will be found is
+in a temporary variable i.e. the generated code will use one or more statements to arrange for the correct
+answer to be in a variable.  To do this, the codegen needs to first get the name of a
 result variable of a suitable type.  This is the "other" reason for making scratch variables.
 
 There are three macros that make this pretty simple.  The first is `CG_RESERVE_RESULT_VAR`
@@ -666,88 +707,89 @@ There are three macros that make this pretty simple.  The first is `CG_RESERVE_R
 // It may or may not be used.  It should be the first thing you put
 // so that it is on the top of your stack.  This only saves the slot.
 #define CG_RESERVE_RESULT_VAR(ast, sem_type) \
-int32_t stack_level_reserved = stack_level; \
-sem_t sem_type_reserved = sem_type; \
-ast_node *ast_reserved = ast; \
-CHARBUF_OPEN(result_var); \
-CHARBUF_OPEN(result_var_is_null); \
-CHARBUF_OPEN(result_var_value); \
-stack_level++;
+  int32_t stack_level_reserved = stack_level; \
+  sem_t sem_type_reserved = sem_type; \
+  ast_node *ast_reserved = ast; \
+  CHARBUF_OPEN(result_var); \
+  CHARBUF_OPEN(result_var_is_null); \
+  CHARBUF_OPEN(result_var_value); \
+  stack_level++;
 ```
 
 If this looks a lot like `PUSH_TEMP` that shouldn't be surprising.  The name of the variable
-and the expression parts always go into `charbuf` variables named `result_var` `result_var_is_null` and `result_var_value`
+and the expression parts always go into `charbuf` variables named `result_var`, `result_var_is_null`, and `result_var_value`
 but the scratch variable isn't actually allocated!  However -- we burn the stack_level as though it had been
-allocated.  What's up with that?
+allocated.
 
-The name might be a clue, this macro reserves stack level slot for the result variable, it's used if you might
-need a result variable, but you might not.  When you want it we can artificially move the stack level back
-to this spot where the slot was burned, allocate the scratch variable, and then put the stack back.
-The `CG_USE_RESULT_VAR` macro does exactly that.
+The name of the macro provides a clue: this macro reserves a slot for the result variable, it's used if the codegen might
+need a result variable, but it might not.  If/when the result variable is needed, it we can artificially move the stack level
+back to the reserved spot, allocate the scratch variable, and then put the stack level back.
+
+The `CG_USE_RESULT_VAR` macro does exactly this operation.
 
 ```C
 // If the result variable is going to be used, this writes its name
 // and .value and .is_null into the is_null and value fields.
 #define CG_USE_RESULT_VAR() \
-int32_t stack_level_now = stack_level; \
-stack_level = stack_level_reserved; \
-cg_scratch_var(ast_reserved, sem_type_reserved, &result_var, &result_var_is_null, &result_var_value); \
-stack_level = stack_level_now; \
-Invariant(result_var.used > 1); \
-bprintf(is_null, "%s", result_var_is_null.ptr); \
-bprintf(value, "%s", result_var_value.ptr)
+  int32_t stack_level_now = stack_level; \
+  stack_level = stack_level_reserved; \
+  cg_scratch_var(ast_reserved, sem_type_reserved, &result_var, &result_var_is_null, &result_var_value); \
+  stack_level = stack_level_now; \
+  Invariant(result_var.used > 1); \
+  bprintf(is_null, "%s", result_var_is_null.ptr); \
+  bprintf(value, "%s", result_var_value.ptr)
 ```
 
 Once the code generator decides that it will in fact be using a result variable to represent the answer, then
 the `is_null` and `value` buffers can be immediately populated to whatever the values were
 for the result variable.  That text will be correct regardless of what codegen is used
-to populate the variable.
+to populate the variable.  The variable is the result.
 
-There is a simpler macro that reserves and uses the result variable in one step, it's very common.  The
-"reserve" pattern is only necessary when there are some paths that need a result variable and some
+There is a simpler macro that reserves and uses the result variable in one step, it's used frequently.
+The "reserve" pattern is only necessary when there are some paths that need a result variable and some
 that don't.
 
-```
+```C
 // This does reserve and use in one step
 #define CG_SETUP_RESULT_VAR(ast, sem_type) \
-CG_RESERVE_RESULT_VAR(ast, sem_type); \
-CG_USE_RESULT_VAR();
+  CG_RESERVE_RESULT_VAR(ast, sem_type); \
+  CG_USE_RESULT_VAR();
 ```
 
-And now armed with this knowledge we can go back to a previous mystery, let's look at `CG_PUSH_EVAL` again
+And now armed with this knowledge we can go back to a previous mystery, let's look at `CG_PUSH_EVAL` again:
 
 ```C
 // Make a temporary buffer for the evaluation results using the canonical naming convention
 // burn the stack slot so that any type and numbered temporary that was needed
 // won't be re-used until this scope is over.
 #define CG_PUSH_EVAL(expr, pri) \
-CHARBUF_OPEN(expr##_is_null); \
-CHARBUF_OPEN(expr##_value); \
-cg_expr(expr, &expr##_is_null, &expr##_value, pri); \
-stack_level++;
-````
+  CHARBUF_OPEN(expr##_is_null); \
+  CHARBUF_OPEN(expr##_value); \
+  cg_expr(expr, &expr##_is_null, &expr##_value, pri); \
+  stack_level++;
+```
 
 The reason that `CG_PUSH_EVAL` includes `stack_level++` is that it is entirely possible, even likely,
 that the result of `cg_expr` is in a result variable.  The convention is that if the codegen
-requires a result variable it is allocated *first* before any other temporaries.  This is why
+requires a result variable it is allocated *first*, before any other temporaries.  This is why
 there is a way to reserve a variable that you *might* need.  When the codegen is complete,
-and before anything else happens, `stack_level` is increased so that the temporary that is
-holding the result will not be re-used!  Any other temporaries are available but the result
-is still live.  This might be easy to get wrong but the macros make it easy to get it right.
+and before anything else happens, `stack_level` is increased so that if a temporary is
+holding the result, it will not be re-used!  Any other temporaries are available, but the result
+is still live.  The macros make it easy to get this stack convention consistently correct.
 
-Now, armed with the knowledge that there a result variables and temporary variables and both
-come from the scratch variable we can resolve the last mystery we left hanging.  Why does
+Now, armed with the knowledge that there are result variables and temporary variables and both
+come from the scratch variables we can resolve the last mystery we left hanging.  Why does
 the scratch variable API accept an AST pointer?
 
-The only place that pointer can be not null is in the `CG_USE_RESULT_VAR` macro, it was
+The only place that AST pointer can be not null is in the `CG_USE_RESULT_VAR` macro, it was
 this line:
 
-```
+```C
 cg_scratch_var(ast_reserved, sem_type_reserved, &result_var, &result_var_is_null, &result_var_value);
 ```
 
 And `ast_reserved` refers to the AST that we are trying to evaluate.  There's an important
-special case that we want to optimize that saves a lot of scratch variables.  It's handled
+special case that we want to optimize that saves a lot of scratch variables.  That case is handled
 by this code in `cg_scratch_var`:
 
 ```C
@@ -829,13 +871,13 @@ static void cg_while_stmt(ast_node *ast) {
 }
 ```
 
-The comment before the `cg_while_stmt` actually says it pretty clearly; the issue is
-that the expression in the while statement might actually require many C statements
-to evaluate.  There are many cases of this sort of thing, but the simplest is
-probably when any nullable types are in that expression.  A particular example
-illustrates this pretty clearly.
+The comment before the `cg_while_stmt` actually describes the situation pretty clearly;
+the issue with this codegen is that the expression in the while statement might actually
+require many C statements to evaluate.  There are many cases of this sort of thing, but the
+simplest is probably when any nullable types are in that expression.  A particular example
+illustrates this pretty clearly:
 
-```C
+```SQL
 CREATE PROC p ()
 BEGIN
   DECLARE x INTEGER NOT NULL;
@@ -845,8 +887,11 @@ BEGIN
     SET x := x + 1;
   END;
 END;
-*/
+```
 
+which generates:
+
+```C
 void p(void) {
   cql_int32 x = 0;
 
@@ -859,11 +904,10 @@ void p(void) {
 }
 ```
 
-In this case, the `while` pattern could have been used because the condition is simply `x < 5` so this whole pattern is
-overkill.  But consider this program just a tiny bit different.
+In this case, a `while` statement could have been used because the condition is simply `x < 5`
+so this more general pattern is overkill.  But consider this program, just a tiny bit different:
 
-```C
-/*
+```SQL
 CREATE PROC p ()
 BEGIN
   DECLARE x INTEGER;  -- x is nullable
@@ -873,8 +917,11 @@ BEGIN
     SET x := x + 1;
   END;
 END;
-*/
+```
 
+which produces:
+
+```C
 void p(void) {
   cql_nullable_int32 x;
   cql_set_null(x);
@@ -891,9 +938,9 @@ void p(void) {
 ```
 
 Even for this small little case, the nullable arithmetic macros have to be used to keep `x` up to date.
-The result of `x < 5` is of type "bool" rather than "bool not null" so a temporary variable captures
-the result of the expression.  This is an easy case but similar things happen if the expression
-includes `CASE...WHEN...` or `IN` constructs.  There are many other cases.
+The result of `x < 5` is of type `BOOL` rather than `BOOL NOT NULL` so a temporary variable captures
+the result of the expression.  This is an easy case, but similar things happen if the expression
+includes e.g. `CASE...WHEN...` or `IN` constructs.  There are many other cases.
 
 So with this in mind, let's reconsider what `cg_while_stmt` is doing:
 
@@ -908,8 +955,9 @@ So with this in mind, let's reconsider what `cg_while_stmt` is doing:
 * finally we end the `for` that we began
 
 This kind of structure is common to all the control flow cases.  Generally, we have to deal with the
-fact that CQL expressions become C statements so we use a more general flow control strategy. But with this
-in mind, it's easy to imagine how `IF` `LOOP` and `SWITCH` are handled.
+fact that CQL expressions often become C statements so we use a more general flow control strategy.
+But with this in mind, it's easy to imagine how the `IF`, `LOOP`, and `SWITCH` switch statements are
+handled.
 
 ### Cleanup and Errors
 
@@ -917,8 +965,7 @@ There are a number of places where things can go wrong when running a CQL proced
 common sources are: (1) SQLite APIs, almost all of which can fail, and, (2) calling other procedures
 which also might fail.  Here's a very simple example:
 
-```C
-/*
+```SQL
 DECLARE PROC something_that_might_fail (arg TEXT) USING TRANSACTION;
 
 CREATE PROC p ()
@@ -926,8 +973,11 @@ BEGIN
   LET arg := "test";
   CALL something_that_might_fail(arg);
 END;
-*/
+```
 
+Which generates:
+
+```C
 cql_string_literal(_literal_1_test_p, "test");
 
 CQL_WARN_UNUSED cql_code p(sqlite3 *_Nonnull _db_) {
@@ -945,25 +995,25 @@ cql_cleanup:
 }
 ```
 
-Let's look at this carefully:
+Let's look at those fragments carefully:
 
 * first, we had to declare `something_that_might_fail`
-  * the declaration includes `USING TRANSACTION` indicating the procedure uses the database
-  * we didn't provide the definition, that will lead to a link time error but we're ignoring that for now
+  * the declaration included `USING TRANSACTION` indicating the procedure uses the database
+  * we didn't provide the procedure definition, this is like an `extern ... foo(...);` declaration
 * there is a string literal named `_literal_1_test_p` that is auto-created
   * `cql_string_literal` can expand into a variety of things, whatever you want "make a string literal" to mean
-  * its defined in `cqlrt.h` and it's designed to be replaced
+  * it's defined in `cqlrt.h` and it's designed to be replaced
 * `cql_set_string_ref(&arg, _literal_1_test_p);` is expected to "retain" the string (+1 ref count)
-* `cql_cleanup` is the exit label, this code will run for sure
+* `cql_cleanup` is the exit label, this cleanup code will run on all exit paths
   * cleanup statements are accumulated by writing to `cg_cleanup_output` which usually writes to the `proc_cleanup` buffer
   * because cleanup is in its own buffer you can add to it freely whenever a new declaration that requires cleanup arises
-  * in this case the declaration of the string literal caused the `C` variable `arg` to be created and also the cleanup code
+  * in this case the declaration of the string variable caused the `C` variable `arg` to be created and also the cleanup code
 *  now we call `something_that_might_fail` passing it our database pointer and the argument
   * the hidden `_db_` pointer is passed to all procedures that use the database
-  * these are also the ones that can fail
-* any failed return code (not `SQLITE_OK`) causes two things
+  * these procedures are also the ones that can fail
+* any failed return code (not `SQLITE_OK`) causes two things:
   * the `cql_error_trace()` macro is invoked (this macro typically expands to nothing)
-  * the code stops what it's doing and runs the cleanup code via `goto cql_cleanup;`
+  * the code is redirected to the cleanup block via `goto cql_cleanup;`
 
 The essential sequence is this one:
 
@@ -971,14 +1021,14 @@ The essential sequence is this one:
  if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
 ```
 
-The C code generator uses this pattern all over to check if anything went wrong and to exit with an error code.
-Extensive logging can be very expensive but in debug builds, it's quite normal for `cql_error_trace` to expand
-into something like `fprintf(stderr, "error %d in %s %s:%d\n", _rc_, _PROC_, __FILE__, __LINE_)` which probably
+The C code generator consistently uses this pattern to check if anything went wrong and to exit with an error code.
+Extensive logging can be very expensive, but in debug builds it's quite normal for `cql_error_trace` to expand
+into something like `fprintf(stderr, "error %d in %s %s:%d\n", _rc_, _PROC_, __FILE__, __LINE_)` which is probably
 a lot more logging than you want in a production build but great if you're debugging.  Recall that CQL generates
-`#define _PROC_ "p"` before every procedure.
+something like `#define _PROC_ "p"` before every procedure.
 
-This pattern generalizes well and indeed if we use the exception handling pattern, we get a lot of control.
-Let's generalize this a tiny bit.
+This error pattern generalizes well and indeed if we use the exception handling pattern, we get a lot of control.
+Let's generalize this example a tiny bit:
 
 ```SQL
 CREATE PROC p (OUT success BOOL NOT NULL)
@@ -1024,16 +1074,16 @@ CQL_WARN_UNUSED cql_code p(sqlite3 *_Nonnull _db_, cql_bool *_Nonnull success) {
 }
 ```
 
-The code is nearly the same.  Let's look at the essential differences:
+The code in this case is nearly the same as the previous example.  Let's look at the essential differences:
 
-* If there is an error, the code hits `goto catch_start_1`
-* If the try block succeeds, the code hits `goto catch_end_1`
-* both branches set the `success` out parameter
-* we added that out argument, CQL generated an error check to ensure that arg 1 is not null
-  * `cql_contract_argument_notnull((void *)success, 1)`, the 1 means arg 1
-  * the hidden `_db_` arg doesn't count
+* If there is an error, `goto catch_start_1` will run
+* If the try block succeeds, `goto catch_end_1` will run
+* both the `TRY` and `CATCH` branches set the `success` out parameter
+* since an out argument was added, CQL generated an error check to ensure that `success` is not null
+  * `cql_contract_argument_notnull((void *)success, 1)`, the 1 means "argument 1" and will appear in the error message if this test fails
+  * the hidden `_db_` argument doesn't count for error message purposes, so `success` is still the first argument
 
-How does this happen?  `cg_trycatch_helper`
+How does this happen?  Let's look at `cg_trycatch_helper` which does this work:
 
 ```C
 // Very little magic is needed to do try/catch in our context.  The error
@@ -1057,10 +1107,12 @@ static void cg_trycatch_helper(ast_node *try_list, ast_node *try_extras, ast_nod
   error_target_used = 0;
  ...
 ```
-All of the error handling does goto `error_target` whatever that is.  The
+
+The secret is the `error_target` global variable.
+All of the error handling will emit a goto `error_target` statement. The
 try/catch pattern simply changes the current error target.  The rest of
-the code is just to save the current error target and to create unique
-labels for the the control flow.
+the code in the helper is just to save the current error target and to
+create unique labels for the try/catch block.
 
 The important notion is that, if anything goes wrong, whatever it is,
 the generator simply does a `goto error_target` and that will either
@@ -1081,14 +1133,14 @@ static void cg_throw_stmt(ast_node *ast) {
 }
 ```
 
-* first we make sure _rc_ has some kind of error in it either `rcthrown_current` or else `SQLITE_ERROR`
-* then we goto the current error target
-* `error_target_used` tracks whether there were any possible errors, this is just to avoid C compiler errors about unused labels.
+* first we make sure `_rc_` has some kind of error in it, either `rcthrown_current` or else `SQLITE_ERROR`
+* then we go to the current error target
+* `error_target_used` tracks whether if the error label was used, this is just to avoid C compiler errors about unused labels.
   * if the label is not used it won't be emitted
-  * the code never jump back to an error label so we'll always know if it was used before we need to emit it
+  * the code never jumps back to an error label, so we'll always know if the label was used before we need to emit it
 
 Note: every catch block captures the value of `_rc_` in a local variable whose name is in `rcthrown_current`.
-This is the current failing result code accessible by `@RC` in CQL.
+This captured value is the current failing result code accessible by `@RC` in CQL.
 
 A catch block can therefore do stuff like:
 
@@ -1100,11 +1152,9 @@ ELSE
 END IF;
 ```
 
-or something like that.
-
 This entire mechanism is built with basically just a few state variables that nest.  There is no complicated stack walking
 or anything like that.  All the code has to do is chain the error labels together and let users create new catch blocks
-with new error labels.  All that together gives you very flexible try/catch behaviour.
+with new error labels.  All that together gives you very flexible try/catch behaviour with very little overhead.
 
 ### String Literals
 
@@ -1965,4 +2015,343 @@ storage for the cursor but it knows it should do so because the cursor variable 
 A cursor without this marking only gets its statement (but not always as we'll see later) and its `_cursor_has_row_`
 hidden variable.
 
-### Coming Soon: Value Cursors
+### Flowing SQLite Statements Between Procedures
+
+Earlier we saw that we can get a cursor from a SQLite `SELECT` statement.  The cursor is used to iterate
+over the `sqlite3_stmt *` that SQLite provides to us.  This process can be done between procedures.  Here's a
+simple example:
+
+```SQL
+@ATTRIBUTE(cql:private)
+CREATE PROC q ()
+BEGIN
+  SELECT "1" AS x, 2 AS y;
+END;
+```
+
+This is the first example of a procedure that return a result set that we've seen.  The wiring for this is
+very simple.
+
+```C
+static CQL_WARN_UNUSED cql_code q(
+  sqlite3 *_Nonnull _db_,
+  sqlite3_stmt *_Nullable *_Nonnull _result_stmt)
+{
+  cql_code _rc_ = SQLITE_OK;
+  *_result_stmt = NULL;
+  _rc_ = cql_prepare(_db_, _result_stmt,
+    "SELECT '1', 2");
+  if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
+  _rc_ = SQLITE_OK;
+
+cql_cleanup:
+  if (_rc_ == SQLITE_OK && !*_result_stmt) _rc_ = cql_no_rows_stmt(_db_, _result_stmt);
+  return _rc_;
+}
+```
+
+First note that there are now *two* hidden parameters to `q`:
+
+* `_db_` : the database pointer as usual,
+* `_result_stmt` : the statement produced by this procedure
+
+The rest of the code is just like any other bound SQL statement.  Note that if
+`_result_stmt` isn't otherwise set by the code it will be initialized to a statement
+that will return zero rows.
+
+All of this is pretty much old news except for the new hidden variable.  Note let's look how we might use
+this.  We can write a procedure that calls `q`, like so:
+
+```SQL
+CREATE PROC p ()
+BEGIN
+  DECLARE C CURSOR FOR CALL q();
+  FETCH C;
+END;
+```
+
+This generates:
+
+```C
+CQL_WARN_UNUSED cql_code p(sqlite3 *_Nonnull _db_) {
+  cql_code _rc_ = SQLITE_OK;
+  sqlite3_stmt *C_stmt = NULL;
+  p_C_row C = { ._refs_count_ = 1, ._refs_offset_ = p_C_refs_offset };
+
+  _rc_ = q(_db_, &C_stmt);
+  if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
+  _rc_ = sqlite3_step(C_stmt);
+  C._has_row_ = _rc_ == SQLITE_ROW;
+  cql_multifetch(_rc_, C_stmt, 2,
+                 CQL_DATA_TYPE_NOT_NULL | CQL_DATA_TYPE_STRING, &C.x,
+                 CQL_DATA_TYPE_NOT_NULL | CQL_DATA_TYPE_INT32, &C.y);
+  if (_rc_ != SQLITE_ROW && _rc_ != SQLITE_DONE) { cql_error_trace(); goto cql_cleanup; }
+  _rc_ = SQLITE_OK;
+
+cql_cleanup:
+  cql_finalize_stmt(&C_stmt);
+  cql_teardown_row(C);
+  return _rc_;
+}
+```
+
+All of the above is *exactly* the same as the previous cases where we got
+data from the database except that instead of using `cql_prepare` the
+compiler produced `_rc_ = q(_db_, &C_stmt);`  That function call gives us,
+of course, a ready-to-use `sqlite3_stmt *` which we can then step, and
+use to fetch values.  The shape of the cursor `C` is determined by the
+result type of procedure `q` -- hence they always match.
+
+If q was in some other module, it could be declared with:
+
+```SQL
+DECLARE PROC q () (x TEXT NOT NULL, y INTEGER NOT NULL);
+```
+
+This is a procedure that takes no arguments and returns a result with the indicated shape.
+
+CQL can generate this declaration for you if you add `--generate_exports` to the command line.  Note
+that in this case `q` was marked with `@attribute(cql:private)` which caused `q` to be `static`
+in the output. Hence it can't be called outside this translation unit and `--generate_exports`
+won't provide the declaration.
+
+If the private annotation were removed, the full exports for this file would be:
+
+```SQL
+DECLARE PROC q () (x TEXT NOT NULL, y INTEGER NOT NULL);
+DECLARE PROC p () USING TRANSACTION;
+```
+
+And these would allow calling both procedures from elsewhere.  Simply `#include` the exports file.
+
+There is a special function in the echoing code that can emit a procedure that was created in the
+form that is needed to declare it, this is `gen_declare_proc_from_create_proc`.
+
+### Value Cursors
+
+Once CQL had the ability to fetch rows into a cursor with no need to declare all the locals
+it was clear that it could benefit from the ability to save a copy of any given row. That is
+basic cursor operations seemed like they should be part of the calculus of CQL.  Here's a
+simple sample program that illustrates this.
+
+```SQL
+CREATE PROC p ()
+BEGIN
+  DECLARE C CURSOR FOR SELECT "1" AS x, 2 AS y;
+  FETCH C;
+  DECLARE D CURSOR LIKE C;
+  FETCH D from C;
+END;
+```
+
+We already have a good idea what is going to happen with `C` in this program.  Let's look at the
+generated code focusing just on the parts that involve `D`.
+
+First there is a row defintion for `D`. Unsurprisingly it is exactly the samea as the one for `C`.
+This must be the case since we specified `D CURSOR LIKE C`.
+
+```C
+typedef struct p_D_row {
+  cql_bool _has_row_;
+  cql_uint16 _refs_count_;
+  cql_uint16 _refs_offset_;
+  cql_int32 y;
+  cql_string_ref _Nonnull x;
+} p_D_row;
+
+#define p_D_refs_offset cql_offsetof(p_D_row, x) // count = 1
+```
+
+Then the `D` cursor variables will be needed:
+
+```C
+p_D_row D = { ._refs_count_ = 1, ._refs_offset_ = p_D_refs_offset };
+```
+
+The above also implies the cleanup code:
+
+```C
+  cql_teardown_row(D);
+```
+
+finally, we fetch `D` from `C`.  That's just some assignments:
+
+```C
+  D._has_row_ = 1;
+  cql_set_string_ref(&D.x, C.x);
+  D.y = C.y;
+```
+
+Importantly, there is no `D_stmt` variable.  `D` is *not* a statement cursor like `C`, it's
+a so-called "value" cursor.  In that it can only hold values.
+
+A value cursor can actually be loaded from anywhere, it just holds data.  You don't
+loop over it (attempts to do so will result in errors).
+
+The general syntax for loading such a cursor is something like this:
+
+```SQL
+ FETCH D(x, y) FROM VALUES(C.x, C.y);
+```
+
+And indeed the form `FETCH D FROM C` was rewritten automatically into the general form.
+The short form is just sugar.
+
+Once loaded, `D.x` and `D.y` can be used as always.  The data type of `D` is similar to `C`.
+
+The AST would report:
+
+```
+{declare_cursor_like_name}: D: select: { x: text notnull, y: integer notnull }
+   variable shape_storage value_cursor
+```
+
+meaning `D` has the flags `SEM_TYPE_STRUCT`, `SEM_TYPE_VARIABLE`, `SEM_TYPE_HAS_SHAPE_STORAGE`, and `SEM_TYPE_VALUE_CURSOR`.
+That last flag indicates that there is no statement for this cursor, it's just values. And all such cursors must have
+`SEM_TYPE_HAS_SHAPE_STORAGE` -- if they had no statement and no storage they would be -- nothing.
+
+Value cursors are enormously helpful and there is sugar for loading them from all kinds of sources with a shape.
+These forms are described more properly in [Chapter 5](https://cgsql.dev/cql-guide/ch05) of the Guide but they
+all end up going through the general form, making the codegen considerably simpler. There are many examples where the semantic
+analyzer rewrites a sugar form to a canonical form to keep the codegen from forking into dozens of special cases
+and most of them have to do with shapes and cursors.
+
+### Returning Value Cursors
+
+Let's look at an example that is similar to the previous one:
+
+```SQL
+@ATTRIBUTE(cql:private)
+CREATE PROC q ()
+BEGIN
+  DECLARE C CURSOR LIKE SELECT "1" AS x, 2 AS y;
+  FETCH C USING
+   "foo" x,
+   3 y;
+  OUT C;
+END;
+
+CREATE PROC p ()
+BEGIN
+  DECLARE C CURSOR FETCH FROM CALL q();
+  -- do something with C
+END;
+```
+
+Let's discuss some of what is above, first looking at `q`:
+
+* `DECLARE C CURSOR LIKE SELECT "1" AS x, 2 AS y;` : this makes an empty value cursor
+  * note the shape is `LIKE` the indicated `SELECT`, the `SELECT` does not actually run
+* `FETCH ... USING` : this form is sugar, it lets you put the column names `x` and `y` adjacent to the values but is otherwise equivalent to the canonical form
+  * `FETCH C(x, y) FROM VALUES("foo", 3);` is the canonical form
+  * codegen only ever sees the canonical form
+* `OUT C` is new, we'll cover this shortly
+
+Now let's look at the C for `q`
+
+```C
+typedef struct q_row {
+  cql_bool _has_row_;
+  cql_uint16 _refs_count_;
+  cql_uint16 _refs_offset_;
+  cql_int32 y;
+  cql_string_ref _Nonnull x;
+} q_row;
+
+#define q_refs_offset cql_offsetof(q_row, x) // count = 1
+
+cql_string_literal(_literal_1_foo_q, "foo");
+
+typedef struct q_C_row {
+  cql_bool _has_row_;
+  cql_uint16 _refs_count_;
+  cql_uint16 _refs_offset_;
+  cql_int32 y;
+  cql_string_ref _Nonnull x;
+} q_C_row;
+
+#define q_C_refs_offset cql_offsetof(q_C_row, x) // count = 1
+
+static void q(q_row *_Nonnull _result_) {
+  memset(_result_, 0, sizeof(*_result_));
+  q_C_row C = { ._refs_count_ = 1, ._refs_offset_ = q_C_refs_offset };
+
+  C._has_row_ = 1;
+  cql_set_string_ref(&C.x, _literal_1_foo_q);
+  C.y = 3;
+  _result_->_has_row_ = C._has_row_;
+  _result_->_refs_count_ = 1;
+  _result_->_refs_offset_ = q_refs_offset;
+  cql_set_string_ref(&_result_->x, C.x);
+  _result_->y = C.y;
+
+  cql_teardown_row(C);
+}
+```
+
+* the `_result_` variable is clobbed with zeros, it is assumed to be junk coming in
+  * if it had valid data, the caller is expected to use `cql_teardown_row` to clean it up *before* calling
+* `q_row` : this is new, this is the structure type for the result of `q`
+  * it's exactly the same shape as C
+  * it has its own `q_refs_offset` like other shapes
+* `q_C_row` : this is the same old same old row structure for cursor C
+* `static void q(q_row *_Nonnull _result_)` : q now accepts a q_row to fill in!
+  * note that `q` does not have the `_db_` parameter, it doesn't use the database!
+  * it is entirely possible to fill value cursors from non-database sources, e.g. constants, math, whatever
+* `C` : the value cursor is declared as usual
+* `C.x` and `C.y` are loaded, this resolves the `FETCH` statement
+* the `_result_` fields are copied from `C`, this resolves the `OUT` statement
+* `C` can be torn down
+* there is no cleanup label, there are no error cases, nothing can go wrong!
+
+
+The net of all this is that we have loaded a value cursor that was passed in to the procedure via
+a hidden argument and it has retained references as appropriate.
+
+Now let's look at `p`:
+
+```C
+typedef struct p_C_row {
+  cql_bool _has_row_;
+  cql_uint16 _refs_count_;
+  cql_uint16 _refs_offset_;
+  cql_int32 y;
+  cql_string_ref _Nonnull x;
+} p_C_row;
+
+#define p_C_refs_offset cql_offsetof(p_C_row, x) // count = 1
+void p(void) {
+  p_C_row C = { ._refs_count_ = 1, ._refs_offset_ = p_C_refs_offset };
+
+  cql_teardown_row(C);
+  q((q_row *)&C); // q_row identical to cursor type
+
+  // usually you do something with C at this point
+
+  cql_teardown_row(C);
+}
+```
+
+* `p_C_row` : the cursor type for `C` in the procedure `p` is defined
+* `p_C_refs_offset` : the refs offset for `C` in `p` as usual
+* `C = {...}` : the usual initialization for a cursor with shape
+  * note that `C` is a value cursor, so it has no `C_stmt`
+* `cql_teardown_row(C)` : releases any references in C, there are none
+  * this pattern is general purpose, the call to `q` might be in a loop or something
+  * in this instance the teardown here is totally redundant, but harmless
+* `q((q_row *)&C)` : fetch `C` by calling `q`
+   * `p_C_row` has been constructed to be exactly the same as `q_row` so this cast is safe
+   * there are no error checks because `q` can't fail!
+* some code that would use `C` is absent for this sample, it would go where the comment is
+* the cleanup label is missing because there are no error cases, emitting the label would just cause warnings
+  * warnings are often escalated to errors in production builds...
+* `cql_teardown_row(C)` is needed as always,
+   * even though there is no cleanup label the `teardown` is in the cleanup section
+   * the `teardown` was added as usual when `C` was declared
+
+So with just normal value cursor codegen we can pretty easily create a situation where
+procedures can move structures from one to another.  As we saw, the source of value cursors
+may or may not be the database.  Value cursors are frequently invaluable in test code
+as they can easily hold mock rows based on any kind of computation.
+
+### Next: Result Sets and OUT UNION


### PR DESCRIPTION
Summary:
Lots of corrections in Part 3.  A small new section on value cursors.  Removed trailing whitespace.

Pull Request resolved: https://github.com/facebookincubator/CG-SQL/pull/71

Test Plan: proof read

Reviewed By: RaoulFoaleng

Differential Revision: D30471651

Pulled By: ricomariani

fbshipit-source-id: 789707e14847f2652b91dddf9d80983aef6bf1e6